### PR TITLE
GPU to SPIR-V conversion

### DIFF
--- a/build_llvm.sh
+++ b/build_llvm.sh
@@ -40,12 +40,6 @@ cd third_party/llvm-project
 
 mkdir -p build && cd build
 
-# TODO uplift LLVM to include this revision
-wget https://reviews.llvm.org/file/data/tcxogj4kn6pdholkebnb/PHID-FILE-uodbv2aluopojlwdnwkr/D126161.diff
-cd ../mlir
-git apply ../build/D126161.diff
-cd ../build
-
 cmake -GNinja -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
   -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" \
   -DLLVM_ENABLE_ASSERTIONS=$ASSERTIONS \

--- a/build_llvm.sh
+++ b/build_llvm.sh
@@ -40,6 +40,11 @@ cd third_party/llvm-project
 
 mkdir -p build && cd build
 
+wget https://reviews.llvm.org/file/data/enmouraycvpkr5ptrpke/PHID-FILE-el4gfzbx3qkdn2w42rk3/D126594.diff
+cd ../mlir
+git apply ../build/D126594.diff
+cd ../build
+
 cmake -GNinja -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
   -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" \
   -DLLVM_ENABLE_ASSERTIONS=$ASSERTIONS \

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(lcl_compiler SHARED
   MetalBackend.cpp
   passes/mlir/AIRKernelABIPass.cpp
   passes/mlir/SPIRToGPUConversion.cpp
+  passes/mlir/ExpandOpenCLFunctionsPass.cpp
+  passes/mlir/GPUToSPIRVPass.cpp
 )
 
 list(APPEND CMAKE_MODULE_PATH

--- a/src/compiler/MetalBackend.cpp
+++ b/src/compiler/MetalBackend.cpp
@@ -1,6 +1,7 @@
 #include "MetalBackend.hpp"
 #include "passes/mlir/passes.hpp"
 
+#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
@@ -10,7 +11,6 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Import.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/IR/Module.h"
@@ -34,13 +34,16 @@ public:
     mContext.loadAllAvailableDialects();
     mlir::registerAllPasses();
 
+    /*
     mContext.disableMultithreading();
     mPM.enableVerifier(false);
     mPM.enableIRPrinting();
+    */
     mPM.addPass(mlir::createCanonicalizerPass());
     mPM.addPass(createSPIRToGPUPass());
     mPM.addPass(mlir::createCanonicalizerPass());
-    mPM.addNestedPass<mlir::gpu::GPUModuleOp>(createExpandOpenCLFunctionsPass());
+    mPM.addNestedPass<mlir::gpu::GPUModuleOp>(
+        createExpandOpenCLFunctionsPass());
     mPM.addPass(mlir::createInlinerPass());
     // mPM.addPass(mlir::createConvertControlFlowToSPIRVPass());
     mPM.addPass(lcl::createGPUToSPIRVPass());

--- a/src/compiler/passes/mlir/ExpandOpenCLFunctionsPass.cpp
+++ b/src/compiler/passes/mlir/ExpandOpenCLFunctionsPass.cpp
@@ -1,5 +1,10 @@
 #include "passes.hpp"
 
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -7,11 +12,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
@@ -25,6 +25,8 @@ void expandGetGlobalId(func::FuncOp func) {
 
   builder.setInsertionPointToStart(&entry);
 
+  Block &elseX = func.getBody().emplaceBlock();
+  Block &elseY = func.getBody().emplaceBlock();
 
   Block &blockX = func.getBody().emplaceBlock();
   Block &blockY = func.getBody().emplaceBlock();
@@ -33,31 +35,70 @@ void expandGetGlobalId(func::FuncOp func) {
   Block &exit = func.getBody().emplaceBlock();
   exit.addArgument(builder.getIndexType(), builder.getUnknownLoc());
 
-  Value defaultVal = builder.create<arith::ConstantOp>(builder.getUnknownLoc(), builder.getIndexAttr(0), builder.getIndexType());
-  builder.create<cf::SwitchOp>(builder.getUnknownLoc(), entry.getArgument(0), &exit, defaultVal, ArrayRef<int32_t>{0, 1, 2}, BlockRange{&blockX, &blockY, &blockZ}, ArrayRef<ValueRange>{ValueRange{}, ValueRange{}, ValueRange{}});
+  Value zero = builder.create<arith::ConstantOp>(
+      builder.getUnknownLoc(), builder.getIntegerAttr(builder.getI32Type(), 0),
+      builder.getI32Type());
+  Value isX = builder.create<arith::CmpIOp>(builder.getUnknownLoc(),
+                                            arith::CmpIPredicate::eq,
+                                            entry.getArgument(0), zero);
+  builder.create<cf::CondBranchOp>(builder.getUnknownLoc(), isX, &blockX,
+                                   ValueRange{}, &elseX, ValueRange{});
 
+  builder.setInsertionPointToStart(&elseX);
+
+  Value one = builder.create<arith::ConstantOp>(
+      builder.getUnknownLoc(), builder.getIntegerAttr(builder.getI32Type(), 1),
+      builder.getI32Type());
+  Value isY = builder.create<arith::CmpIOp>(builder.getUnknownLoc(),
+                                            arith::CmpIPredicate::eq,
+                                            entry.getArgument(0), zero);
+  builder.create<cf::CondBranchOp>(builder.getUnknownLoc(), isY, &blockY,
+                                   ValueRange{}, &elseY, ValueRange{});
+
+  builder.setInsertionPointToStart(&elseY);
+  Value two = builder.create<arith::ConstantOp>(
+      builder.getUnknownLoc(), builder.getIntegerAttr(builder.getI32Type(), 2),
+      builder.getI32Type());
+  Value defaultVal = builder.create<arith::ConstantOp>(
+      builder.getUnknownLoc(), builder.getIndexAttr(0), builder.getIndexType());
+  Value isZ = builder.create<arith::CmpIOp>(builder.getUnknownLoc(),
+                                            arith::CmpIPredicate::eq,
+                                            entry.getArgument(0), zero);
+  builder.create<cf::CondBranchOp>(builder.getUnknownLoc(), isZ, &blockZ,
+                                   ValueRange{}, &exit, ValueRange{defaultVal});
+  // builder.create<cf::SwitchOp>(builder.getUnknownLoc(), entry.getArgument(0),
+  // &exit, defaultVal, ArrayRef<int32_t>{0, 1, 2}, BlockRange{&blockX, &blockY,
+  // &blockZ}, ArrayRef<ValueRange>{ValueRange{}, ValueRange{}, ValueRange{}});
+  // TODO replace with cf::SwitchOp once OpSwitch is supported in SPIR-V
+  // conversion
 
   builder.setInsertionPointToStart(&blockX);
-  auto xDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::x);
-  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{xDim});
+  auto xDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(),
+                                              gpu::Dimension::x);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit,
+                               ValueRange{xDim});
 
   builder.setInsertionPointToStart(&blockY);
-  auto yDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::y);
-  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{yDim});
+  auto yDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(),
+                                              gpu::Dimension::y);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit,
+                               ValueRange{yDim});
 
   builder.setInsertionPointToStart(&blockZ);
-  auto zDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::z);
-  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{zDim});
+  auto zDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(),
+                                              gpu::Dimension::z);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit,
+                               ValueRange{zDim});
 
   builder.setInsertionPointToStart(&exit);
-  auto res = builder.create<arith::IndexCastOp>(builder.getUnknownLoc(), builder.getI64Type(), exit.getArgument(0));
+  auto res = builder.create<arith::IndexCastOp>(
+      builder.getUnknownLoc(), builder.getI64Type(), exit.getArgument(0));
   builder.create<func::ReturnOp>(builder.getUnknownLoc(), res.getOut());
-
 }
 
 struct ExpandOpenCLFunctionsPass
     : public PassWrapper<ExpandOpenCLFunctionsPass,
-                               OperationPass<gpu::GPUModuleOp>> {
+                         OperationPass<gpu::GPUModuleOp>> {
   void runOnOperation() override {
     gpu::GPUModuleOp module = getOperation();
 
@@ -66,10 +107,10 @@ struct ExpandOpenCLFunctionsPass
       expandGetGlobalId(getGlobalId);
   }
 };
-}
+} // namespace
 
 namespace lcl {
 std::unique_ptr<Pass> createExpandOpenCLFunctionsPass() {
   return std::make_unique<ExpandOpenCLFunctionsPass>();
 }
-}
+} // namespace lcl

--- a/src/compiler/passes/mlir/ExpandOpenCLFunctionsPass.cpp
+++ b/src/compiler/passes/mlir/ExpandOpenCLFunctionsPass.cpp
@@ -1,0 +1,75 @@
+#include "passes.hpp"
+
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace {
+void expandGetGlobalId(func::FuncOp func) {
+  OpBuilder builder(func.getContext());
+
+  Block &entry = func.getBody().emplaceBlock();
+  entry.addArgument(builder.getI32Type(), builder.getUnknownLoc());
+
+  builder.setInsertionPointToStart(&entry);
+
+
+  Block &blockX = func.getBody().emplaceBlock();
+  Block &blockY = func.getBody().emplaceBlock();
+  Block &blockZ = func.getBody().emplaceBlock();
+
+  Block &exit = func.getBody().emplaceBlock();
+  exit.addArgument(builder.getIndexType(), builder.getUnknownLoc());
+
+  Value defaultVal = builder.create<arith::ConstantOp>(builder.getUnknownLoc(), builder.getIndexAttr(0), builder.getIndexType());
+  builder.create<cf::SwitchOp>(builder.getUnknownLoc(), entry.getArgument(0), &exit, defaultVal, ArrayRef<int32_t>{0, 1, 2}, BlockRange{&blockX, &blockY, &blockZ}, ArrayRef<ValueRange>{ValueRange{}, ValueRange{}, ValueRange{}});
+
+
+  builder.setInsertionPointToStart(&blockX);
+  auto xDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::x);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{xDim});
+
+  builder.setInsertionPointToStart(&blockY);
+  auto yDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::y);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{yDim});
+
+  builder.setInsertionPointToStart(&blockZ);
+  auto zDim = builder.create<gpu::GlobalIdOp>(builder.getUnknownLoc(), gpu::Dimension::z);
+  builder.create<cf::BranchOp>(builder.getUnknownLoc(), &exit, ValueRange{zDim});
+
+  builder.setInsertionPointToStart(&exit);
+  auto res = builder.create<arith::IndexCastOp>(builder.getUnknownLoc(), builder.getI64Type(), exit.getArgument(0));
+  builder.create<func::ReturnOp>(builder.getUnknownLoc(), res.getOut());
+
+}
+
+struct ExpandOpenCLFunctionsPass
+    : public PassWrapper<ExpandOpenCLFunctionsPass,
+                               OperationPass<gpu::GPUModuleOp>> {
+  void runOnOperation() override {
+    gpu::GPUModuleOp module = getOperation();
+
+    auto getGlobalId = module.lookupSymbol<func::FuncOp>("_Z13get_global_idj");
+    if (getGlobalId)
+      expandGetGlobalId(getGlobalId);
+  }
+};
+}
+
+namespace lcl {
+std::unique_ptr<Pass> createExpandOpenCLFunctionsPass() {
+  return std::make_unique<ExpandOpenCLFunctionsPass>();
+}
+}

--- a/src/compiler/passes/mlir/GPUToSPIRVPass.cpp
+++ b/src/compiler/passes/mlir/GPUToSPIRVPass.cpp
@@ -1,0 +1,205 @@
+#include "passes.hpp"
+
+#include "mlir/Conversion/GPUToSPIRV/GPUToSPIRVPass.h"
+
+#include "../../dialects/RawMemory/RawMemoryDialect.h"
+#include "../../dialects/RawMemory/RawMemoryOps.h"
+#include "../../dialects/RawMemory/RawMemoryTypes.h"
+#include "mlir/Conversion/ArithmeticToSPIRV/ArithmeticToSPIRV.h"
+#include "mlir/Conversion/FuncToSPIRV/FuncToSPIRV.h"
+#include "mlir/Conversion/GPUToSPIRV/GPUToSPIRV.h"
+#include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+#include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRV.h"
+
+using namespace mlir;
+
+namespace {
+struct GPUToSPIRVPass
+    : public PassWrapper<GPUToSPIRVPass,
+                               OperationPass<ModuleOp>> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp module = getOperation();
+
+    SmallVector<Operation *, 1> kernelModules;
+    OpBuilder builder(context);
+    module.walk([&builder, &kernelModules](gpu::GPUModuleOp moduleOp) {
+      // For each kernel module (should be only 1 for now, but that is not a
+      // requirement here), clone the module for conversion because the
+      // gpu.launch function still needs the kernel module.
+      builder.setInsertionPoint(moduleOp.getOperation());
+      kernelModules.push_back(builder.clone(*moduleOp.getOperation()));
+    });
+
+    auto targetAttr = spirv::lookupTargetEnvOrDefault(module);
+    std::unique_ptr<ConversionTarget> target =
+        SPIRVConversionTarget::get(targetAttr);
+
+    SPIRVTypeConverter typeConverter(targetAttr);
+    RewritePatternSet patterns(context);
+    populateGPUToSPIRVPatterns(typeConverter, patterns);
+
+    // TODO: Change SPIR-V conversion to be progressive and remove the following
+    // patterns.
+    mlir::arith::populateArithmeticToSPIRVPatterns(typeConverter, patterns);
+    populateMemRefToSPIRVPatterns(typeConverter, patterns);
+    populateFuncToSPIRVPatterns(typeConverter, patterns);
+    cf::populateControlFlowToSPIRVPatterns(typeConverter, patterns);
+
+    lcl::populateRawMemoryToSPIRVTypeConversions(typeConverter, targetAttr);
+    lcl::populateRawMemoryToSPIRVConversionPatterns(typeConverter, patterns);
+
+    if (failed(applyFullConversion(kernelModules, *target, std::move(patterns))))
+      return signalPassFailure();
+    }
+};
+
+struct LoadPattern : public OpConversionPattern<rawmem::LoadOp> {
+  using Base = OpConversionPattern<rawmem::LoadOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(rawmem::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // TODO access chain
+    rewriter.replaceOpWithNewOp<spirv::LoadOp>(op, adaptor.addr());
+
+    return success();
+  }
+};
+
+struct StorePattern : public OpConversionPattern<rawmem::StoreOp> {
+  using Base = OpConversionPattern<rawmem::StoreOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(rawmem::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    rewriter.replaceOpWithNewOp<spirv::StoreOp>(op, adaptor.addr(), adaptor.value());
+
+    return success();
+  }
+};
+
+struct OffsetPattern : public OpConversionPattern<rawmem::OffsetOp> {
+  using Base = OpConversionPattern<rawmem::OffsetOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(rawmem::OffsetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    rewriter.replaceOpWithNewOp<spirv::AccessChainOp>(op, adaptor.addr(), adaptor.offset());
+
+    return success();
+  }
+};
+
+struct ReinterpretCastPattern : public OpConversionPattern<rawmem::ReinterpretCastOp> {
+  using Base = OpConversionPattern<rawmem::ReinterpretCastOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(rawmem::ReinterpretCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    Type type = getTypeConverter()->convertType(op.out().getType().cast<rawmem::PointerType>());
+    rewriter.replaceOpWithNewOp<spirv::BitcastOp>(op, type, adaptor.addr());
+
+    return success();
+  }
+};
+
+struct FuncPattern : public OpConversionPattern<func::FuncOp> {
+  using Base = OpConversionPattern<func::FuncOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::FuncOp funcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto fnType = funcOp.getFunctionType();
+
+    // Update the signature to valid SPIR-V types and add the ABI
+    // attributes. These will be "materialized" by using the
+    // LowerABIAttributesPass.
+    TypeConverter::SignatureConversion signatureConverter(fnType.getNumInputs());
+    {
+      for (const auto &argType :
+           enumerate(funcOp.getFunctionType().getInputs())) {
+        auto convertedType = getTypeConverter()->convertType(argType.value());
+        signatureConverter.addInputs(argType.index(), convertedType);
+      }
+    }
+    SmallVector<Type, 1> retTypes;
+    for (auto t : fnType.getResults()) {
+      retTypes.push_back(getTypeConverter()->convertType(t));
+    }
+    auto newFuncOp = rewriter.create<spirv::FuncOp>(
+        funcOp.getLoc(), funcOp.getName(),
+        rewriter.getFunctionType(signatureConverter.getConvertedTypes(),
+                                 retTypes));
+    for (const auto &namedAttr : funcOp->getAttrs()) {
+      if (namedAttr.getName() == FunctionOpInterface::getTypeAttrName() ||
+          namedAttr.getName() == SymbolTable::getSymbolAttrName())
+        continue;
+      newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+    }
+
+    rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
+                                newFuncOp.end());
+    if (failed(rewriter.convertRegionTypes(&newFuncOp.getBody(), *getTypeConverter(),
+                                           &signatureConverter)))
+      return failure();
+    rewriter.eraseOp(funcOp);
+
+    return success();
+  }
+};
+}
+
+static mlir::spirv::StorageClass addrSpaceToVulkanStorageClass(unsigned addrSpace) {
+  switch (addrSpace) {
+    case 1:
+      return spirv::StorageClass::CrossWorkgroup;
+    default:
+      llvm_unreachable("Unknown address space");
+  }
+}
+
+static mlir::spirv::StorageClass addrSpaceToStorageClass(unsigned addrSpace, mlir::spirv::TargetEnvAttr) {
+  // TODO OpenCL?
+  return addrSpaceToVulkanStorageClass(addrSpace);
+}
+
+void lcl::populateRawMemoryToSPIRVTypeConversions(mlir::TypeConverter &converter, mlir::spirv::TargetEnvAttr env) {
+  converter.addConversion([=, &converter](rawmem::PointerType ptr) {
+    auto sc = addrSpaceToStorageClass(ptr.getAddressSpace(), env);
+    Type type;
+    if (ptr.isOpaque()) {
+      type = IntegerType::get(ptr.getContext(), 8);
+    } else {
+      type = converter.convertType(ptr.getElementType());
+    }
+
+    return spirv::PointerType::get(type, sc);
+  });
+}
+void lcl::populateRawMemoryToSPIRVConversionPatterns(mlir::TypeConverter &converter,
+                                                mlir::RewritePatternSet &patterns) {
+  patterns.add<LoadPattern, StorePattern, OffsetPattern, ReinterpretCastPattern, FuncPattern>(converter, patterns.getContext());
+}
+
+std::unique_ptr<mlir::Pass> lcl::createGPUToSPIRVPass() {
+  return std::make_unique<GPUToSPIRVPass>();
+}

--- a/src/compiler/passes/mlir/SPIRToGPUConversion.cpp
+++ b/src/compiler/passes/mlir/SPIRToGPUConversion.cpp
@@ -7,10 +7,10 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
@@ -91,6 +91,18 @@ struct FuncConversionPattern : public OpConversionPattern<LLVM::LLVMFuncOp> {
       rewriter.setInsertionPointToStart(&module.getBodyRegion().front());
       gpuModule =
           rewriter.create<gpu::GPUModuleOp>(module.getLoc(), "ocl_program");
+      auto triple = spirv::VerCapExtAttr::get(
+          spirv::Version::V_1_3,
+          {spirv::Capability::Shader, spirv::Capability::Addresses,
+           spirv::Capability::Float64, spirv::Capability::Int64,
+           spirv::Capability::Int8},
+          ArrayRef<spirv::Extension>(), module.getContext());
+
+      auto attr = spirv::TargetEnvAttr::get(
+          triple, spirv::Vendor::Unknown, spirv::DeviceType::Unknown,
+          spirv::TargetEnvAttr::kUnknownDeviceID,
+          spirv::getDefaultResourceLimits(module.getContext()));
+      module->setAttr(spirv::getTargetEnvAttrName(), attr);
     }
 
     auto funcType = func.getFunctionType();
@@ -129,9 +141,11 @@ struct FuncConversionPattern : public OpConversionPattern<LLVM::LLVMFuncOp> {
       }
 
       if (func.getCConv() == LLVM::CConv::SPIR_KERNEL) {
-        gpuFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(), rewriter.getUnitAttr());
+        gpuFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
+                         rewriter.getUnitAttr());
 
-        auto abi = spirv::getEntryPointABIAttr(ArrayRef<int32_t>{1, 1, 1}, func.getContext());
+        auto abi = spirv::getEntryPointABIAttr(ArrayRef<int32_t>{1, 1, 1},
+                                               func.getContext());
         gpuFunc->setAttr(spirv::getEntryPointABIAttrName(), abi);
       }
     } else {

--- a/src/compiler/passes/mlir/passes.hpp
+++ b/src/compiler/passes/mlir/passes.hpp
@@ -6,6 +6,9 @@ namespace mlir {
 class Pass;
 class RewritePatternSet;
 class TypeConverter;
+namespace spirv {
+class TargetEnvAttr;
+}
 }
 
 namespace lcl {
@@ -13,6 +16,12 @@ void populateSPIRToGPUTypeConversions(mlir::TypeConverter &);
 void populateSPIRToGPUConversionPatterns(mlir::TypeConverter &,
                                          mlir::RewritePatternSet &);
 
+void populateRawMemoryToSPIRVTypeConversions(mlir::TypeConverter &, mlir::spirv::TargetEnvAttr);
+void populateRawMemoryToSPIRVConversionPatterns(mlir::TypeConverter &,
+                                                mlir::RewritePatternSet &);
+
 std::unique_ptr<mlir::Pass> createSPIRToGPUPass();
 std::unique_ptr<mlir::Pass> createAIRKernelABIPass();
+std::unique_ptr<mlir::Pass> createExpandOpenCLFunctionsPass();
+std::unique_ptr<mlir::Pass> createGPUToSPIRVPass();
 }

--- a/src/compiler/passes/mlir/passes.hpp
+++ b/src/compiler/passes/mlir/passes.hpp
@@ -16,7 +16,8 @@ void populateSPIRToGPUTypeConversions(mlir::TypeConverter &);
 void populateSPIRToGPUConversionPatterns(mlir::TypeConverter &,
                                          mlir::RewritePatternSet &);
 
-void populateRawMemoryToSPIRVTypeConversions(mlir::TypeConverter &, mlir::spirv::TargetEnvAttr);
+void populateRawMemoryToSPIRVTypeConversions(mlir::TypeConverter &,
+                                             mlir::spirv::TargetEnvAttr);
 void populateRawMemoryToSPIRVConversionPatterns(mlir::TypeConverter &,
                                                 mlir::RewritePatternSet &);
 

--- a/tools/lcloc/main.cpp
+++ b/tools/lcloc/main.cpp
@@ -4,11 +4,10 @@
 
 const char *kernelSource =
     "\n"
-    "#pragma OPENCL EXTENSION cl_khr_fp64 : enable                    \n"
     // "void foo() {}                                                    \n"
-    "__kernel void vecAdd(  __global double *a,                       \n"
-    "                       __global double *b,                       \n"
-    "                       __global double *c,                       \n"
+    "__kernel void vecAdd(  __global float *a,                       \n"
+    "                       __global float *b,                       \n"
+    "                       __global float *c,                       \n"
     "                       const unsigned int n)                    \n"
     "{                                                               \n"
     "    //Get our global thread ID                                  \n"


### PR DESCRIPTION
Add conversion from GPU dialect to SPIR-V dialect. Resulting IR looks like this:

```mlir
module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>>, spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader, Addresses, Float64, Int64, Int8], []>, {}>} {
  spv.module @__spv__ocl_program Logical GLSL450 {
    spv.GlobalVariable @__builtin_var_GlobalInvocationId__ built_in("GlobalInvocationId") : !spv.ptr<vector<3xi32>, Input>
    spv.func @_Z13get_global_idj(%arg0: i32) -> i64 "None" attributes {sym_visibility = "private"} {
      %cst0_i32 = spv.Constant 0 : i32
      %cst0_i32_0 = spv.Constant 0 : i32
      %0 = spv.IEqual %arg0, %cst0_i32_0 : i32
      spv.BranchConditional %0, ^bb3, ^bb1
    ^bb1:  // pred: ^bb0
      %1 = spv.IEqual %arg0, %cst0_i32_0 : i32
      spv.BranchConditional %1, ^bb4, ^bb2
    ^bb2:  // pred: ^bb1
      %2 = spv.IEqual %arg0, %cst0_i32_0 : i32
      spv.BranchConditional %2, ^bb5, ^bb6(%cst0_i32 : i32)
    ^bb3:  // pred: ^bb0
      %__builtin_var_GlobalInvocationId___addr = spv.mlir.addressof @__builtin_var_GlobalInvocationId__ : !spv.ptr<vector<3xi32>, Input>
      %3 = spv.Load "Input" %__builtin_var_GlobalInvocationId___addr : vector<3xi32>
      %4 = spv.CompositeExtract %3[0 : i32] : vector<3xi32>
      spv.Branch ^bb6(%4 : i32)
    ^bb4:  // pred: ^bb1
      %__builtin_var_GlobalInvocationId___addr_1 = spv.mlir.addressof @__builtin_var_GlobalInvocationId__ : !spv.ptr<vector<3xi32>, Input>
      %5 = spv.Load "Input" %__builtin_var_GlobalInvocationId___addr_1 : vector<3xi32>
      %6 = spv.CompositeExtract %5[1 : i32] : vector<3xi32>
      spv.Branch ^bb6(%6 : i32)
    ^bb5:  // pred: ^bb2
      %__builtin_var_GlobalInvocationId___addr_2 = spv.mlir.addressof @__builtin_var_GlobalInvocationId__ : !spv.ptr<vector<3xi32>, Input>
      %7 = spv.Load "Input" %__builtin_var_GlobalInvocationId___addr_2 : vector<3xi32>
      %8 = spv.CompositeExtract %7[2 : i32] : vector<3xi32>
      spv.Branch ^bb6(%8 : i32)
    ^bb6(%9: i32):  // 4 preds: ^bb2, ^bb3, ^bb4, ^bb5
      %10 = spv.SConvert %9 : i32 to i64
      spv.ReturnValue %10 : i64
    }
    spv.func @vecAdd(%arg0: !spv.ptr<i8, CrossWorkgroup> {spv.interface_var_abi = #spv.interface_var_abi<(0, 0)>}, %arg1: !spv.ptr<i8, CrossWorkgroup> {spv.interface_var_abi = #spv.interface_var_abi<(0, 1)>}, %arg2: !spv.ptr<i8, CrossWorkgroup> {spv.interface_var_abi = #spv.interface_var_abi<(0, 2)>}, %arg3: i32 {spv.interface_var_abi = #spv.interface_var_abi<(0, 3), StorageBuffer>}) "None" attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
      %cst0_i32 = spv.Constant 0 : i32
      %0 = spv.FunctionCall @_Z13get_global_idj(%cst0_i32) : (i32) -> i64
      %1 = spv.SConvert %0 : i64 to i32
      %2 = spv.ULessThan %1, %arg3 : i32
      spv.BranchConditional %2, ^bb1, ^bb2
    ^bb1:  // pred: ^bb0
      %3 = spv.Bitcast %arg0 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      %4 = spv.PtrAccessChain %3[%1] : !spv.ptr<f32, CrossWorkgroup>, i32
      %5 = spv.Bitcast %4 : !spv.ptr<f32, CrossWorkgroup> to !spv.ptr<i8, CrossWorkgroup>
      %6 = spv.Bitcast %5 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      %7 = spv.Load "CrossWorkgroup" %6 : f32
      %8 = spv.Bitcast %arg1 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      %9 = spv.PtrAccessChain %8[%1] : !spv.ptr<f32, CrossWorkgroup>, i32
      %10 = spv.Bitcast %9 : !spv.ptr<f32, CrossWorkgroup> to !spv.ptr<i8, CrossWorkgroup>
      %11 = spv.Bitcast %10 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      %12 = spv.Load "CrossWorkgroup" %11 : f32
      %13 = spv.FAdd %7, %12 : f32
      %14 = spv.Bitcast %arg2 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      %15 = spv.PtrAccessChain %14[%1] : !spv.ptr<f32, CrossWorkgroup>, i32
      %16 = spv.Bitcast %15 : !spv.ptr<f32, CrossWorkgroup> to !spv.ptr<i8, CrossWorkgroup>
      %17 = spv.Bitcast %16 : !spv.ptr<i8, CrossWorkgroup> to !spv.ptr<f32, CrossWorkgroup>
      spv.Store "CrossWorkgroup" %17, %13 : f32
      spv.Branch ^bb2
    ^bb2:  // 2 preds: ^bb0, ^bb1
      spv.Return
    }
  }
  gpu.module @ocl_program {
    func.func private @_Z13get_global_idj(%arg0: i32) -> i64 {
      %c0 = arith.constant 0 : index
      %c0_i32 = arith.constant 0 : i32
      %0 = arith.cmpi eq, %arg0, %c0_i32 : i32
      cf.cond_br %0, ^bb3, ^bb1
    ^bb1:  // pred: ^bb0
      %1 = arith.cmpi eq, %arg0, %c0_i32 : i32
      cf.cond_br %1, ^bb4, ^bb2
    ^bb2:  // pred: ^bb1
      %2 = arith.cmpi eq, %arg0, %c0_i32 : i32
      cf.cond_br %2, ^bb5, ^bb6(%c0 : index)
    ^bb3:  // pred: ^bb0
      %3 = gpu.global_id  x
      cf.br ^bb6(%3 : index)
    ^bb4:  // pred: ^bb1
      %4 = gpu.global_id  y
      cf.br ^bb6(%4 : index)
    ^bb5:  // pred: ^bb2
      %5 = gpu.global_id  z
      cf.br ^bb6(%5 : index)
    ^bb6(%6: index):  // 4 preds: ^bb2, ^bb3, ^bb4, ^bb5
      %7 = arith.index_cast %6 : index to i64
      return %7 : i64
    }
    gpu.func @vecAdd(%arg0: !rawmem.ptr<1>, %arg1: !rawmem.ptr<1>, %arg2: !rawmem.ptr<1>, %arg3: i32) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}} {
      %c0_i32 = arith.constant 0 : i32
      %0 = func.call @_Z13get_global_idj(%c0_i32) : (i32) -> i64
      %1 = arith.trunci %0 : i64 to i32
      %2 = arith.cmpi ult, %1, %arg3 : i32
      cf.cond_br %2, ^bb1, ^bb2
    ^bb1:  // pred: ^bb0
      %3 = rawmem.reinterpret_cast %arg0 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      %4 = arith.index_cast %1 : i32 to index
      %5 = rawmem.offset %3[%4] : !rawmem.ptr<f32, 1>
      %6 = rawmem.reinterpret_cast %5 !rawmem.ptr<f32, 1> to !rawmem.ptr<1>
      %7 = rawmem.reinterpret_cast %6 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      %8 = rawmem.load %7 : !rawmem.ptr<f32, 1>, f32
      %9 = rawmem.reinterpret_cast %arg1 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      %10 = arith.index_cast %1 : i32 to index
      %11 = rawmem.offset %9[%10] : !rawmem.ptr<f32, 1>
      %12 = rawmem.reinterpret_cast %11 !rawmem.ptr<f32, 1> to !rawmem.ptr<1>
      %13 = rawmem.reinterpret_cast %12 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      %14 = rawmem.load %13 : !rawmem.ptr<f32, 1>, f32
      %15 = arith.addf %8, %14 : f32
      %16 = rawmem.reinterpret_cast %arg2 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      %17 = arith.index_cast %1 : i32 to index
      %18 = rawmem.offset %16[%17] : !rawmem.ptr<f32, 1>
      %19 = rawmem.reinterpret_cast %18 !rawmem.ptr<f32, 1> to !rawmem.ptr<1>
      %20 = rawmem.reinterpret_cast %19 !rawmem.ptr<1> to !rawmem.ptr<f32, 1>
      rawmem.store %15, %20 : f32, !rawmem.ptr<f32, 1>
      cf.br ^bb2
    ^bb2:  // 2 preds: ^bb0, ^bb1
      gpu.return
    }
  }
}
```