### PR TITLE
feat(compiler): add SPIR-V frontend

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -37,7 +37,7 @@ jobs:
           key: llvm-${{ runner.os }}-${{ github.sha }}
           restore-keys: llvm-${{ runner.os }}-
       - name: Build LLVM
-        run: ./build_llvm.sh
+        run: ./build_dependencies.sh
       #- name: Configure LibreCL
       #  run: ./configure.sh
       #- name: Build LibreCL

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -45,7 +45,10 @@ git apply ../../llvm_patches/D126594.diff
 git apply ../../llvm_patches/lower_abi.diff
 cd ../build
 
-cmake -GNinja -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
+cmake -GNinja \
+  -DLLVM_EXTERNAL_PROJECTS="llvm-spirv" \
+  -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR="$PWD/../../SPIRV-LLVM-Translator" \
+  -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
   -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" \
   -DLLVM_ENABLE_ASSERTIONS=$ASSERTIONS \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -55,3 +58,4 @@ cmake -GNinja -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
   ../llvm/
 
 ninja
+

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(dialects/RawMemory)
 add_library(lcl_compiler SHARED
   frontend.cpp
   ClangFrontend.cpp
+  SPIRVFrontend.cpp
   MetalBackend.cpp
   VulkanBackend.cpp
   VulkanSPVBackendImpl.cpp
@@ -91,6 +92,7 @@ target_include_directories(lcl_compiler SYSTEM PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CLANG_INCLUDE_DIRS}
   ${MLIR_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/third_party/SPIRV-LLVM-Translator/include
   )
 
 target_include_directories(lcl_compiler PRIVATE
@@ -130,4 +132,5 @@ target_link_libraries(lcl_compiler PRIVATE
   MLIRLLVMToLLVMIRTranslation
   MLIRToLLVMIRTranslationRegistration
   MLIRSPIRVSerialization
+  LLVMSPIRVLib
 )

--- a/src/compiler/ClangFrontend.cpp
+++ b/src/compiler/ClangFrontend.cpp
@@ -52,7 +52,6 @@ public:
 
     mDiagOpts->ShowPresumedLoc = true;
   }
-
   FrontendResult process(const std::string_view source,
                          const llvm::ArrayRef<llvm::StringRef> options) {
     std::string errString;

--- a/src/compiler/SPIRVFrontend.cpp
+++ b/src/compiler/SPIRVFrontend.cpp
@@ -1,0 +1,62 @@
+//===- SPIRVFrontend.hpp ----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVFrontend.hpp"
+#include "frontend_impl.hpp"
+
+#include "LLVMSPIRVLib.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+
+#include <sstream>
+
+namespace lcl {
+namespace detail {
+class SPIRVFrontendImpl {
+public:
+  SPIRVFrontendImpl() {}
+
+  FrontendResult process(const std::string_view source,
+                         const llvm::ArrayRef<llvm::StringRef> options) {
+    // TODO this must be copy-free one day, as SPIR-V files tend to be extremely
+    // large, up to a few gigabytes.
+    std::string spv{source};
+
+    std::istringstream stream{spv};
+
+    llvm::Module *module;
+
+    std::string error;
+    if (!llvm::readSpirv(mContext, stream, module, error)) {
+      return FrontendResult{error};
+    }
+
+    std::unique_ptr<llvm::Module> finalModule{module};
+    module = nullptr;
+
+    return FrontendResult{
+        std::make_shared<detail::Module>(std::move(finalModule))};
+  }
+
+private:
+  llvm::LLVMContext mContext;
+};
+
+} // namespace detail
+SPIRVFrontend::SPIRVFrontend()
+    : mImpl(std::make_shared<detail::SPIRVFrontendImpl>()) {}
+
+FrontendResult SPIRVFrontend::process(std::string_view input,
+                                      std::span<std::string_view> options) {
+  llvm::SmallVector<llvm::StringRef, 15> opts;
+  for (std::string_view opt : options) {
+    opts.push_back(llvm::StringRef{opt});
+  }
+  return mImpl->process(input, opts);
+}
+} // namespace lcl

--- a/src/compiler/SPIRVFrontend.hpp
+++ b/src/compiler/SPIRVFrontend.hpp
@@ -1,0 +1,34 @@
+//===- SPIRVFrontend.hpp ----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "frontend.hpp"
+#include "visibility.hpp"
+
+#include <memory>
+#include <span>
+#include <string_view>
+
+namespace lcl {
+namespace detail {
+class SPIRVFrontendImpl;
+}
+class LCL_COMP_EXPORT SPIRVFrontend : public Frontend {
+public:
+  SPIRVFrontend();
+
+  FrontendResult process(std::string_view input,
+                         std::span<std::string_view> options) final;
+
+  ~SPIRVFrontend() = default;
+
+private:
+  std::shared_ptr<detail::SPIRVFrontendImpl> mImpl;
+};
+} // namespace lcl

--- a/tools/lcloc/main.cpp
+++ b/tools/lcloc/main.cpp
@@ -8,6 +8,7 @@
 
 #include "ClangFrontend.hpp"
 #include "MetalBackend.hpp"
+#include "SPIRVFrontend.hpp"
 #include "VulkanBackend.hpp"
 
 #include "llvm/Support/CommandLine.h"
@@ -28,6 +29,10 @@ using out_func_t = std::function<void(std::span<const char>)>;
 
 std::unique_ptr<lcl::Frontend> prepareClangFrontend() {
   return std::make_unique<lcl::ClangFrontend>();
+}
+
+std::unique_ptr<lcl::Frontend> prepareSPIRVFrontent() {
+  return std::make_unique<lcl::SPIRVFrontend>();
 }
 
 std::unique_ptr<lcl::Backend>
@@ -112,7 +117,12 @@ int main(int argc, char **argv) {
                         std::istreambuf_iterator<char>()};
 
   // TODO prepare SPIR-V frontend depending on file extension
-  auto FE = prepareClangFrontend();
+  std::unique_ptr<lcl::Frontend> FE;
+  if (inputFilename.ends_with(".spv")) {
+    FE = prepareSPIRVFrontent();
+  } else {
+    FE = prepareClangFrontend();
+  }
 
   auto IR = FE->process(inputData, {});
 


### PR DESCRIPTION
SPIR-V frontend leverages SPIR-V to LLVM translator from Khronos (https://github.com/KhronosGroup/SPIRV-LLVM-Translator) to convert SPIR-V to SPIR-df LLVM IR and then processes it with standard LibreCL transformation pipeline.