### PR TITLE
feat(compiler): emit Metal Shading Language source code from MLIR

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,7 @@ jobs:
   build_test:
     strategy:
       matrix:
-       os: ['ubuntu-22.04', 'macOS-12']
+       os: ['ubuntu-22.04']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -38,8 +38,9 @@ jobs:
           restore-keys: llvm-${{ runner.os }}-
       - name: Build LLVM
         run: ./build_dependencies.sh
-      #- name: Configure LibreCL
-      #  run: ./configure.sh
-      #- name: Build LibreCL
-      #  run: cd build && ninja
-        # TODO run tests
+      - name: Configure LibreCL
+        run: ./configure.sh
+      - name: Build LibreCL
+        run: cd build && ninja
+      - name: Run tests
+        run: cd build && ninja check-lcl

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo apt install -yqq ccache ninja-build libtbb-dev
       - name: Install macOS dependencies
         if: matrix.os == 'macOS-12'
-        run:
+        run: |
           brew install ccache ninja tbb ncurses
           echo 'export PATH="/usr/local/opt/ncurses/bin:$PATH"' >> /Users/runner/.bash_profile
           echo "PKG_CONFIG_PATH=\"/usr/local/opt/ncurses/lib/pkgconfig\"" > $GITHUB_ENV

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macOS-12'
         run:
-          brew install ccache ninja tbb
+          brew install ccache ninja tbb ncurses
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,8 @@ jobs:
         if: matrix.os == 'macOS-12'
         run:
           brew install ccache ninja tbb ncurses
+          echo 'export PATH="/usr/local/opt/ncurses/bin:$PATH"' >> /Users/runner/.bash_profile
+          echo "PKG_CONFIG_PATH=\"/usr/local/opt/ncurses/lib/pkgconfig\"" > $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,3 +78,5 @@ add_subdirectory(examples)
 add_subdirectory(src)
 add_subdirectory(tools)
 add_subdirectory(third_party)
+add_subdirectory(test)
+

--- a/configure.sh
+++ b/configure.sh
@@ -44,5 +44,6 @@ cmake -GNinja \
   -DClang_DIR=$PWD/../third_party/llvm-project/build/lib/cmake/clang \
   -DLLVM_ENABLE_ASSERTIONS=OFF \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DLLVM_ENABLE_TERMINFo=OFF \
   -DLIBRECL_LINKER="$LINKER" \
   ..

--- a/configure.sh
+++ b/configure.sh
@@ -44,6 +44,6 @@ cmake -GNinja \
   -DClang_DIR=$PWD/../third_party/llvm-project/build/lib/cmake/clang \
   -DLLVM_ENABLE_ASSERTIONS=OFF \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-  -DLLVM_ENABLE_TERMINFo=OFF \
+  -DLLVM_ENABLE_TERMINFO=OFF \
   -DLIBRECL_LINKER="$LINKER" \
   ..

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -5,6 +5,7 @@ else ()
 endif ()
 
 add_subdirectory(dialects/RawMemory)
+add_subdirectory(passes/mlir)
 
 add_library(lcl_compiler SHARED
   frontend.cpp
@@ -13,11 +14,6 @@ add_library(lcl_compiler SHARED
   MetalBackend.cpp
   VulkanBackend.cpp
   VulkanSPVBackendImpl.cpp
-  passes/mlir/AIRKernelABIPass.cpp
-  passes/mlir/SPIRToGPUConversion.cpp
-  passes/mlir/ExpandOpenCLFunctionsPass.cpp
-  passes/mlir/GPUToSPIRVPass.cpp
-  passes/mlir/InferPointerTypesPass.cpp
 )
 
 list(APPEND CMAKE_MODULE_PATH
@@ -133,4 +129,5 @@ target_link_libraries(lcl_compiler PRIVATE
   MLIRToLLVMIRTranslationRegistration
   MLIRSPIRVSerialization
   LLVMSPIRVLib
+  LCLPasses
 )

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(lcl_compiler SHARED
   MetalBackend.cpp
   VulkanBackend.cpp
   VulkanSPVBackendImpl.cpp
+  TranslateToCpp.cpp
 )
 
 list(APPEND CMAKE_MODULE_PATH

--- a/src/compiler/CppEmitter.hpp
+++ b/src/compiler/CppEmitter.hpp
@@ -1,0 +1,31 @@
+//===- CppEmitter.h - Helpers to create C++ emitter -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines helpers to emit C++ code using the EmitC dialect.
+//
+//===----------------------------------------------------------------------===//
+
+// Derived from mlir/include/mlir/Target/Cpp/CppEmitter.h
+
+#pragma once
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/ScopedHashTable.h"
+#include "llvm/Support/raw_ostream.h"
+#include <stack>
+
+namespace lcl {
+
+/// Translates the given operation to C++ code. The operation or operations in
+/// the region of 'op' need almost all be in EmitC dialect. The parameter
+/// 'declareVariablesAtTop' enforces that all variables for op results and block
+/// arguments are declared at the beginning of the function.
+mlir::LogicalResult translateToCpp(mlir::Operation *op, mlir::raw_ostream &os,
+                                   bool declareVariablesAtTop = false);
+} // namespace lcl

--- a/src/compiler/MetalBackend.cpp
+++ b/src/compiler/MetalBackend.cpp
@@ -8,6 +8,7 @@
 
 #include "MetalBackend.hpp"
 #include "VulkanSPVBackendImpl.hpp"
+#include "passes/mlir/passes.hpp"
 #include "visibility.hpp"
 
 #include "mlir/Dialect/GPU/GPUDialect.h"
@@ -37,10 +38,15 @@ namespace lcl {
 namespace detail {
 class LCL_COMP_EXPORT MetalBackendImpl : public VulkanSPVBackendImpl {
 public:
-  MetalBackendImpl() : VulkanSPVBackendImpl() {}
+  MetalBackendImpl() : VulkanSPVBackendImpl(/*initializeSPV*/ false) {
+    mPM.addNestedPass<mlir::gpu::GPUModuleOp>(createAIRKernelABIPass());
+  }
 
   std::vector<unsigned char>
   compile(std::unique_ptr<llvm::Module> module) override {
+    VulkanSPVBackendImpl::prepareLLVMModule(module);
+    auto mlirModule = VulkanSPVBackendImpl::convertLLVMIRToMLIR(module);
+    /*
     std::vector<unsigned char> spv =
         VulkanSPVBackendImpl::compile(std::move(module));
     spirv_cross::CompilerMSL mslComp(reinterpret_cast<uint32_t *>(spv.data()),
@@ -52,6 +58,9 @@ public:
     std::string source = mslComp.compile();
 
     mMSLPrinter(source);
+    */
+
+    std::string source = "dummy";
 
     return std::vector<unsigned char>{
         reinterpret_cast<unsigned char *>(source.data()),

--- a/src/compiler/MetalBackend.cpp
+++ b/src/compiler/MetalBackend.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MetalBackend.hpp"
+#include "CppEmitter.hpp"
 #include "VulkanSPVBackendImpl.hpp"
 #include "passes/mlir/passes.hpp"
 #include "visibility.hpp"
@@ -29,10 +30,11 @@
 
 #include "RawMemory/RawMemoryDialect.h"
 
+#include <iostream>
+#include <llvm/Support/raw_ostream.h>
 #include <memory>
 #include <spirv_msl.hpp>
 #include <vector>
-#include <iostream>
 
 namespace lcl {
 namespace detail {
@@ -40,29 +42,24 @@ class LCL_COMP_EXPORT MetalBackendImpl : public VulkanSPVBackendImpl {
 public:
   MetalBackendImpl() : VulkanSPVBackendImpl(/*initializeSPV*/ false) {
     mPM.addNestedPass<mlir::gpu::GPUModuleOp>(createAIRKernelABIPass());
-    // mPM.addPass(createExpandGPUBuiltinsPass());
+    mPM.addPass(createExpandGPUBuiltinsPass());
+    mPM.addPass(mlir::createCanonicalizerPass());
+    mPM.addPass(createGPUToCppPass());
   }
 
   std::vector<unsigned char>
   compile(std::unique_ptr<llvm::Module> module) override {
     VulkanSPVBackendImpl::prepareLLVMModule(module);
     auto mlirModule = VulkanSPVBackendImpl::convertLLVMIRToMLIR(module);
-    /*
-    std::vector<unsigned char> spv =
-        VulkanSPVBackendImpl::compile(std::move(module));
-    spirv_cross::CompilerMSL mslComp(reinterpret_cast<uint32_t *>(spv.data()),
-                                     spv.size() / sizeof(uint32_t));
-    spirv_cross::CompilerMSL::Options mslOpts;
-    mslOpts.set_msl_version(2, 2);
-    mslOpts.vertex_index_type =
-    spirv_cross::CompilerMSL::Options::IndexType::UInt32;
-    mslComp.set_msl_options(mslOpts);
-    std::string source = mslComp.compile();
+
+    std::string source;
+    llvm::raw_string_ostream mslStream{source};
+    // TODO check for errors
+    lcl::translateToCpp(mlirModule.get(), mslStream, true);
+
+    mslStream.flush();
 
     mMSLPrinter(source);
-    */
-
-    std::string source = "dummy";
 
     return std::vector<unsigned char>{
         reinterpret_cast<unsigned char *>(source.data()),

--- a/src/compiler/MetalBackend.cpp
+++ b/src/compiler/MetalBackend.cpp
@@ -53,7 +53,8 @@ public:
                                      spv.size() / sizeof(uint32_t));
     spirv_cross::CompilerMSL::Options mslOpts;
     mslOpts.set_msl_version(2, 2);
-    mslOpts.vertex_index_type = spirv_cross::CompilerMSL::Options::IndexType::UInt32;
+    mslOpts.vertex_index_type =
+    spirv_cross::CompilerMSL::Options::IndexType::UInt32;
     mslComp.set_msl_options(mslOpts);
     std::string source = mslComp.compile();
 

--- a/src/compiler/MetalBackend.cpp
+++ b/src/compiler/MetalBackend.cpp
@@ -40,6 +40,7 @@ class LCL_COMP_EXPORT MetalBackendImpl : public VulkanSPVBackendImpl {
 public:
   MetalBackendImpl() : VulkanSPVBackendImpl(/*initializeSPV*/ false) {
     mPM.addNestedPass<mlir::gpu::GPUModuleOp>(createAIRKernelABIPass());
+    // mPM.addPass(createExpandGPUBuiltinsPass());
   }
 
   std::vector<unsigned char>

--- a/src/compiler/TranslateToCpp.cpp
+++ b/src/compiler/TranslateToCpp.cpp
@@ -1,0 +1,1254 @@
+//===- TranslateToCpp.cpp - Translating to C++ calls ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Derived from mlir/lib/Target/Cpp/TranslateToCpp.cpp
+
+#include "CppEmitter.hpp"
+#include "RawMemory/RawMemoryOps.h"
+#include "RawMemory/RawMemoryTypes.h"
+
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <mlir/Dialect/Vector/IR/VectorOps.h>
+#include <mlir/IR/Diagnostics.h>
+#include <mlir/Support/LogicalResult.h>
+#include <utility>
+
+#define DEBUG_TYPE "translate-to-cpp"
+
+using namespace mlir;
+using namespace mlir::emitc;
+using llvm::formatv;
+
+/// Convenience functions to produce interleaved output with functions returning
+/// a LogicalResult. This is different than those in STLExtras as functions used
+/// on each element doesn't return a string.
+template <typename ForwardIterator, typename UnaryFunctor,
+          typename NullaryFunctor>
+inline LogicalResult
+interleaveWithError(ForwardIterator begin, ForwardIterator end,
+                    UnaryFunctor eachFn, NullaryFunctor betweenFn) {
+  if (begin == end)
+    return success();
+  if (failed(eachFn(*begin)))
+    return failure();
+  ++begin;
+  for (; begin != end; ++begin) {
+    betweenFn();
+    if (failed(eachFn(*begin)))
+      return failure();
+  }
+  return success();
+}
+
+template <typename Container, typename UnaryFunctor, typename NullaryFunctor>
+inline LogicalResult interleaveWithError(const Container &c,
+                                         UnaryFunctor eachFn,
+                                         NullaryFunctor betweenFn) {
+  return interleaveWithError(c.begin(), c.end(), eachFn, betweenFn);
+}
+
+template <typename Container, typename UnaryFunctor>
+inline LogicalResult interleaveCommaWithError(const Container &c,
+                                              raw_ostream &os,
+                                              UnaryFunctor eachFn) {
+  return interleaveWithError(c.begin(), c.end(), eachFn, [&]() { os << ", "; });
+}
+
+namespace {
+/// Emitter that uses dialect specific emitters to emit C++ code.
+struct CppEmitter {
+  explicit CppEmitter(raw_ostream &os, bool declareVariablesAtTop);
+
+  /// Emits attribute or returns failure.
+  LogicalResult emitAttribute(Location loc, Attribute attr);
+
+  /// Emits operation 'op' with/without training semicolon or returns failure.
+  LogicalResult emitOperation(Operation &op, bool trailingSemicolon);
+
+  /// Emits type 'type' or returns failure.
+  LogicalResult emitType(Location loc, Type type);
+
+  /// Emits array of types as a std::tuple of the emitted types.
+  /// - emits void for an empty array;
+  /// - emits the type of the only element for arrays of size one;
+  /// - emits a std::tuple otherwise;
+  LogicalResult emitTypes(Location loc, ArrayRef<Type> types);
+
+  /// Emits array of types as a std::tuple of the emitted types independently of
+  /// the array size.
+  LogicalResult emitTupleType(Location loc, ArrayRef<Type> types);
+
+  /// Emits an assignment for a variable which has been declared previously.
+  LogicalResult emitVariableAssignment(OpResult result);
+
+  /// Emits a variable declaration for a result of an operation.
+  LogicalResult emitVariableDeclaration(OpResult result,
+                                        bool trailingSemicolon);
+
+  /// Emits the variable declaration and assignment prefix for 'op'.
+  /// - emits separate variable followed by std::tie for multi-valued operation;
+  /// - emits single type followed by variable for single result;
+  /// - emits nothing if no value produced by op;
+  /// Emits final '=' operator where a type is produced. Returns failure if
+  /// any result type could not be converted.
+  LogicalResult emitAssignPrefix(Operation &op);
+
+  /// Emits a label for the block.
+  LogicalResult emitLabel(Block &block);
+
+  /// Emits the operands and atttributes of the operation. All operands are
+  /// emitted first and then all attributes in alphabetical order.
+  LogicalResult emitOperandsAndAttributes(Operation &op,
+                                          ArrayRef<StringRef> exclude = {});
+
+  /// Emits the operands of the operation. All operands are emitted in order.
+  LogicalResult emitOperands(Operation &op);
+
+  /// Return the existing or a new name for a Value.
+  StringRef getOrCreateName(Value val);
+
+  /// Return the existing or a new label of a Block.
+  StringRef getOrCreateName(Block &block);
+
+  /// Whether to map an mlir integer to a unsigned integer in C++.
+  bool shouldMapToUnsigned(IntegerType::SignednessSemantics val);
+
+  /// RAII helper function to manage entering/exiting C++ scopes.
+  struct Scope {
+    Scope(CppEmitter &emitter)
+        : valueMapperScope(emitter.valueMapper),
+          blockMapperScope(emitter.blockMapper), emitter(emitter) {
+      emitter.valueInScopeCount.push(emitter.valueInScopeCount.top());
+      emitter.labelInScopeCount.push(emitter.labelInScopeCount.top());
+    }
+    ~Scope() {
+      emitter.valueInScopeCount.pop();
+      emitter.labelInScopeCount.pop();
+    }
+
+  private:
+    llvm::ScopedHashTableScope<Value, std::string> valueMapperScope;
+    llvm::ScopedHashTableScope<Block *, std::string> blockMapperScope;
+    CppEmitter &emitter;
+  };
+
+  /// Returns wether the Value is assigned to a C++ variable in the scope.
+  bool hasValueInScope(Value val);
+
+  // Returns whether a label is assigned to the block.
+  bool hasBlockLabel(Block &block);
+
+  /// Returns the output stream.
+  raw_indented_ostream &ostream() { return os; };
+
+  /// Returns if all variables for op results and basic block arguments need to
+  /// be declared at the beginning of a function.
+  bool shouldDeclareVariablesAtTop() { return declareVariablesAtTop; };
+
+private:
+  using ValueMapper = llvm::ScopedHashTable<Value, std::string>;
+  using BlockMapper = llvm::ScopedHashTable<Block *, std::string>;
+
+  /// Output stream to emit to.
+  raw_indented_ostream os;
+
+  /// Boolean to enforce that all variables for op results and block
+  /// arguments are declared at the beginning of the function. This also
+  /// includes results from ops located in nested regions.
+  bool declareVariablesAtTop;
+
+  /// Map from value to name of C++ variable that contain the name.
+  ValueMapper valueMapper;
+
+  /// Map from block to name of C++ label.
+  BlockMapper blockMapper;
+
+  /// The number of values in the current scope. This is used to declare the
+  /// names of values in a scope.
+  std::stack<int64_t> valueInScopeCount;
+  std::stack<int64_t> labelInScopeCount;
+};
+} // namespace
+
+static LogicalResult printConstantOp(CppEmitter &emitter, Operation *operation,
+                                     Attribute value) {
+  OpResult result = operation->getResult(0);
+
+  // Only emit an assignment as the variable was already declared when printing
+  // the FuncOp.
+  if (emitter.shouldDeclareVariablesAtTop()) {
+    // Skip the assignment if the emitc.constant has no value.
+    if (auto oAttr = value.dyn_cast<emitc::OpaqueAttr>()) {
+      if (oAttr.getValue().empty())
+        return success();
+    }
+
+    if (failed(emitter.emitVariableAssignment(result)))
+      return failure();
+    return emitter.emitAttribute(operation->getLoc(), value);
+  }
+
+  // Emit a variable declaration for an emitc.constant op without value.
+  if (auto oAttr = value.dyn_cast<emitc::OpaqueAttr>()) {
+    if (oAttr.getValue().empty())
+      // The semicolon gets printed by the emitOperation function.
+      return emitter.emitVariableDeclaration(result,
+                                             /*trailingSemicolon=*/false);
+  }
+
+  // Emit a variable declaration.
+  if (failed(emitter.emitAssignPrefix(*operation)))
+    return failure();
+  return emitter.emitAttribute(operation->getLoc(), value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::ConstantOp constantOp) {
+  Operation *operation = constantOp.getOperation();
+  Attribute value = constantOp.value();
+
+  return printConstantOp(emitter, operation, value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::VariableOp variableOp) {
+  Operation *operation = variableOp.getOperation();
+  Attribute value = variableOp.value();
+
+  return printConstantOp(emitter, operation, value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    arith::ConstantOp constantOp) {
+  Operation *operation = constantOp.getOperation();
+  Attribute value = constantOp.getValue();
+
+  return printConstantOp(emitter, operation, value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, arith::CmpIOp cmpOp) {
+  if (failed(emitter.emitAssignPrefix(*cmpOp.getOperation())))
+    return failure();
+
+  emitter.ostream() << emitter.getOrCreateName(cmpOp.getLhs());
+
+  switch (cmpOp.getPredicate()) {
+  case arith::CmpIPredicate::eq:
+    emitter.ostream() << " == ";
+    break;
+  case arith::CmpIPredicate::ne:
+    emitter.ostream() << " != ";
+    break;
+  case arith::CmpIPredicate::sle:
+  case arith::CmpIPredicate::ule:
+    emitter.ostream() << " < ";
+    break;
+  case arith::CmpIPredicate::slt:
+  case arith::CmpIPredicate::ult:
+    emitter.ostream() << " <= ";
+    break;
+  case arith::CmpIPredicate::sge:
+  case arith::CmpIPredicate::uge:
+    emitter.ostream() << " > ";
+    break;
+  case arith::CmpIPredicate::sgt:
+  case arith::CmpIPredicate::ugt:
+    emitter.ostream() << " >= ";
+    break;
+  }
+
+  emitter.ostream() << emitter.getOrCreateName(cmpOp.getRhs());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    arith::IndexCastOp castOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &op = *castOp.getOperation();
+
+  if (failed(emitter.emitAssignPrefix(op)))
+    return failure();
+  os << "(";
+  if (failed(emitter.emitType(op.getLoc(), op.getResult(0).getType())))
+    return failure();
+  os << ") ";
+  os << emitter.getOrCreateName(castOp.getOperand());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    arith::TruncIOp castOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &op = *castOp.getOperation();
+
+  if (failed(emitter.emitAssignPrefix(op)))
+    return failure();
+  os << "(";
+  if (failed(emitter.emitType(op.getLoc(), op.getResult(0).getType())))
+    return failure();
+  os << ") ";
+  os << emitter.getOrCreateName(castOp.getOperand());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    vector::ExtractElementOp extOp) {
+  if (failed(emitter.emitAssignPrefix(*extOp.getOperation())))
+    return failure();
+
+  emitter.ostream() << emitter.getOrCreateName(extOp.getVector());
+  emitter.ostream() << '[' << emitter.getOrCreateName(extOp.getPosition())
+                    << ']';
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    rawmem::LoadOp loadOp) {
+  if (failed(emitter.emitAssignPrefix(*loadOp.getOperation())))
+    return failure();
+
+  emitter.ostream() << emitter.getOrCreateName(loadOp.addr());
+  // TODO support multiple indices
+  emitter.ostream() << '[';
+  if (loadOp.indices().size() == 0) {
+    emitter.ostream() << '0';
+  } else if (loadOp.indices().size() == 1) {
+    emitter.ostream() << emitter.getOrCreateName(loadOp.indices().front())
+                      << ']';
+  } else {
+    return emitError(loadOp.getLoc(), "Multiple indices are not supported yet");
+  }
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    rawmem::StoreOp storeOp) {
+  emitter.ostream() << emitter.getOrCreateName(storeOp.addr());
+  // TODO support multiple indices
+  emitter.ostream() << '[';
+  if (storeOp.indices().size() == 0) {
+    emitter.ostream() << '0';
+  } else if (storeOp.indices().size() == 1) {
+    emitter.ostream() << emitter.getOrCreateName(storeOp.indices().front())
+                      << ']';
+  } else {
+    return emitError(storeOp.getLoc(),
+                     "Multiple indices are not supported yet");
+  }
+
+  emitter.ostream() << " = ";
+  emitter.ostream() << emitter.getOrCreateName(storeOp.value());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, arith::AddFOp addOp) {
+  if (failed(emitter.emitAssignPrefix(*addOp.getOperation())))
+    return failure();
+
+  emitter.ostream() << emitter.getOrCreateName(addOp.getLhs());
+  emitter.ostream() << " + ";
+  emitter.ostream() << emitter.getOrCreateName(addOp.getRhs());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    func::ConstantOp constantOp) {
+  Operation *operation = constantOp.getOperation();
+  Attribute value = constantOp.getValueAttr();
+
+  return printConstantOp(emitter, operation, value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    cf::BranchOp branchOp) {
+  raw_ostream &os = emitter.ostream();
+  Block &successor = *branchOp.getSuccessor();
+
+  for (auto pair :
+       llvm::zip(branchOp.getOperands(), successor.getArguments())) {
+    Value &operand = std::get<0>(pair);
+    BlockArgument &argument = std::get<1>(pair);
+    os << emitter.getOrCreateName(argument) << " = "
+       << emitter.getOrCreateName(operand) << ";\n";
+  }
+
+  os << "goto ";
+  if (!(emitter.hasBlockLabel(successor)))
+    return branchOp.emitOpError("unable to find label for successor block");
+  os << emitter.getOrCreateName(successor);
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    cf::CondBranchOp condBranchOp) {
+  raw_indented_ostream &os = emitter.ostream();
+  Block &trueSuccessor = *condBranchOp.getTrueDest();
+  Block &falseSuccessor = *condBranchOp.getFalseDest();
+
+  os << "if (" << emitter.getOrCreateName(condBranchOp.getCondition())
+     << ") {\n";
+
+  os.indent();
+
+  // If condition is true.
+  for (auto pair : llvm::zip(condBranchOp.getTrueOperands(),
+                             trueSuccessor.getArguments())) {
+    Value &operand = std::get<0>(pair);
+    BlockArgument &argument = std::get<1>(pair);
+    os << emitter.getOrCreateName(argument) << " = "
+       << emitter.getOrCreateName(operand) << ";\n";
+  }
+
+  os << "goto ";
+  if (!(emitter.hasBlockLabel(trueSuccessor))) {
+    return condBranchOp.emitOpError("unable to find label for successor block");
+  }
+  os << emitter.getOrCreateName(trueSuccessor) << ";\n";
+  os.unindent() << "} else {\n";
+  os.indent();
+  // If condition is false.
+  for (auto pair : llvm::zip(condBranchOp.getFalseOperands(),
+                             falseSuccessor.getArguments())) {
+    Value &operand = std::get<0>(pair);
+    BlockArgument &argument = std::get<1>(pair);
+    os << emitter.getOrCreateName(argument) << " = "
+       << emitter.getOrCreateName(operand) << ";\n";
+  }
+
+  os << "goto ";
+  if (!(emitter.hasBlockLabel(falseSuccessor))) {
+    return condBranchOp.emitOpError()
+           << "unable to find label for successor block";
+  }
+  os << emitter.getOrCreateName(falseSuccessor) << ";\n";
+  os.unindent() << "}";
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, func::CallOp callOp) {
+  if (failed(emitter.emitAssignPrefix(*callOp.getOperation())))
+    return failure();
+
+  raw_ostream &os = emitter.ostream();
+  os << callOp.getCallee() << "(";
+  if (failed(emitter.emitOperands(*callOp.getOperation())))
+    return failure();
+  os << ")";
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, emitc::CallOp callOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &op = *callOp.getOperation();
+
+  if (failed(emitter.emitAssignPrefix(op)))
+    return failure();
+  os << callOp.callee();
+
+  auto emitArgs = [&](Attribute attr) -> LogicalResult {
+    if (auto t = attr.dyn_cast<IntegerAttr>()) {
+      // Index attributes are treated specially as operand index.
+      if (t.getType().isIndex()) {
+        int64_t idx = t.getInt();
+        if ((idx < 0) || (idx >= op.getNumOperands()))
+          return op.emitOpError("invalid operand index");
+        if (!emitter.hasValueInScope(op.getOperand(idx)))
+          return op.emitOpError("operand ")
+                 << idx << "'s value not defined in scope";
+        os << emitter.getOrCreateName(op.getOperand(idx));
+        return success();
+      }
+    }
+    if (failed(emitter.emitAttribute(op.getLoc(), attr)))
+      return failure();
+
+    return success();
+  };
+
+  if (callOp.template_args()) {
+    os << "<";
+    if (failed(interleaveCommaWithError(*callOp.template_args(), os, emitArgs)))
+      return failure();
+    os << ">";
+  }
+
+  os << "(";
+
+  LogicalResult emittedArgs =
+      callOp.args() ? interleaveCommaWithError(*callOp.args(), os, emitArgs)
+                    : emitter.emitOperands(op);
+  if (failed(emittedArgs))
+    return failure();
+  os << ")";
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::ApplyOp applyOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &op = *applyOp.getOperation();
+
+  if (failed(emitter.emitAssignPrefix(op)))
+    return failure();
+  os << applyOp.applicableOperator();
+  os << emitter.getOrCreateName(applyOp.getOperand());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, emitc::CastOp castOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &op = *castOp.getOperation();
+
+  if (failed(emitter.emitAssignPrefix(op)))
+    return failure();
+  os << "(";
+  if (failed(emitter.emitType(op.getLoc(), op.getResult(0).getType())))
+    return failure();
+  os << ") ";
+  os << emitter.getOrCreateName(castOp.getOperand());
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::IncludeOp includeOp) {
+  raw_ostream &os = emitter.ostream();
+
+  os << "#include ";
+  if (includeOp.is_standard_include())
+    os << "<" << includeOp.include() << ">";
+  else
+    os << "\"" << includeOp.include() << "\"";
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, scf::ForOp forOp) {
+
+  raw_indented_ostream &os = emitter.ostream();
+
+  OperandRange operands = forOp.getIterOperands();
+  Block::BlockArgListType iterArgs = forOp.getRegionIterArgs();
+  Operation::result_range results = forOp.getResults();
+
+  if (!emitter.shouldDeclareVariablesAtTop()) {
+    for (OpResult result : results) {
+      if (failed(emitter.emitVariableDeclaration(result,
+                                                 /*trailingSemicolon=*/true)))
+        return failure();
+    }
+  }
+
+  for (auto pair : llvm::zip(iterArgs, operands)) {
+    if (failed(emitter.emitType(forOp.getLoc(), std::get<0>(pair).getType())))
+      return failure();
+    os << " " << emitter.getOrCreateName(std::get<0>(pair)) << " = ";
+    os << emitter.getOrCreateName(std::get<1>(pair)) << ";";
+    os << "\n";
+  }
+
+  os << "for (";
+  if (failed(
+          emitter.emitType(forOp.getLoc(), forOp.getInductionVar().getType())))
+    return failure();
+  os << " ";
+  os << emitter.getOrCreateName(forOp.getInductionVar());
+  os << " = ";
+  os << emitter.getOrCreateName(forOp.getLowerBound());
+  os << "; ";
+  os << emitter.getOrCreateName(forOp.getInductionVar());
+  os << " < ";
+  os << emitter.getOrCreateName(forOp.getUpperBound());
+  os << "; ";
+  os << emitter.getOrCreateName(forOp.getInductionVar());
+  os << " += ";
+  os << emitter.getOrCreateName(forOp.getStep());
+  os << ") {\n";
+  os.indent();
+
+  Region &forRegion = forOp.getRegion();
+  auto regionOps = forRegion.getOps();
+
+  // We skip the trailing yield op because this updates the result variables
+  // of the for op in the generated code. Instead we update the iterArgs at
+  // the end of a loop iteration and set the result variables after the for
+  // loop.
+  for (auto it = regionOps.begin(); std::next(it) != regionOps.end(); ++it) {
+    if (failed(emitter.emitOperation(*it, /*trailingSemicolon=*/true)))
+      return failure();
+  }
+
+  Operation *yieldOp = forRegion.getBlocks().front().getTerminator();
+  // Copy yield operands into iterArgs at the end of a loop iteration.
+  for (auto pair : llvm::zip(iterArgs, yieldOp->getOperands())) {
+    BlockArgument iterArg = std::get<0>(pair);
+    Value operand = std::get<1>(pair);
+    os << emitter.getOrCreateName(iterArg) << " = "
+       << emitter.getOrCreateName(operand) << ";\n";
+  }
+
+  os.unindent() << "}";
+
+  // Copy iterArgs into results after the for loop.
+  for (auto pair : llvm::zip(results, iterArgs)) {
+    OpResult result = std::get<0>(pair);
+    BlockArgument iterArg = std::get<1>(pair);
+    os << "\n"
+       << emitter.getOrCreateName(result) << " = "
+       << emitter.getOrCreateName(iterArg) << ";";
+  }
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, scf::IfOp ifOp) {
+  raw_indented_ostream &os = emitter.ostream();
+
+  if (!emitter.shouldDeclareVariablesAtTop()) {
+    for (OpResult result : ifOp.getResults()) {
+      if (failed(emitter.emitVariableDeclaration(result,
+                                                 /*trailingSemicolon=*/true)))
+        return failure();
+    }
+  }
+
+  os << "if (";
+  if (failed(emitter.emitOperands(*ifOp.getOperation())))
+    return failure();
+  os << ") {\n";
+  os.indent();
+
+  Region &thenRegion = ifOp.getThenRegion();
+  for (Operation &op : thenRegion.getOps()) {
+    // Note: This prints a superfluous semicolon if the terminating yield op has
+    // zero results.
+    if (failed(emitter.emitOperation(op, /*trailingSemicolon=*/true)))
+      return failure();
+  }
+
+  os.unindent() << "}";
+
+  Region &elseRegion = ifOp.getElseRegion();
+  if (!elseRegion.empty()) {
+    os << " else {\n";
+    os.indent();
+
+    for (Operation &op : elseRegion.getOps()) {
+      // Note: This prints a superfluous semicolon if the terminating yield op
+      // has zero results.
+      if (failed(emitter.emitOperation(op, /*trailingSemicolon=*/true)))
+        return failure();
+    }
+
+    os.unindent() << "}";
+  }
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, scf::YieldOp yieldOp) {
+  raw_ostream &os = emitter.ostream();
+  Operation &parentOp = *yieldOp.getOperation()->getParentOp();
+
+  if (yieldOp.getNumOperands() != parentOp.getNumResults()) {
+    return yieldOp.emitError("number of operands does not to match the number "
+                             "of the parent op's results");
+  }
+
+  if (failed(interleaveWithError(
+          llvm::zip(parentOp.getResults(), yieldOp.getOperands()),
+          [&](auto pair) -> LogicalResult {
+            auto result = std::get<0>(pair);
+            auto operand = std::get<1>(pair);
+            os << emitter.getOrCreateName(result) << " = ";
+
+            if (!emitter.hasValueInScope(operand))
+              return yieldOp.emitError("operand value not in scope");
+            os << emitter.getOrCreateName(operand);
+            return success();
+          },
+          [&]() { os << ";\n"; })))
+    return failure();
+
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    func::ReturnOp returnOp) {
+  raw_ostream &os = emitter.ostream();
+  os << "return";
+  switch (returnOp.getNumOperands()) {
+  case 0:
+    return success();
+  case 1:
+    os << " " << emitter.getOrCreateName(returnOp.getOperand(0));
+    return success(emitter.hasValueInScope(returnOp.getOperand(0)));
+  default:
+    os << " std::make_tuple(";
+    if (failed(emitter.emitOperandsAndAttributes(*returnOp.getOperation())))
+      return failure();
+    os << ")";
+    return success();
+  }
+}
+
+static LogicalResult printOperation(CppEmitter &emitter, ModuleOp moduleOp) {
+  CppEmitter::Scope scope(emitter);
+
+  for (Operation &op : moduleOp) {
+    if (failed(emitter.emitOperation(op, /*trailingSemicolon=*/false)))
+      return failure();
+  }
+  return success();
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    func::FuncOp functionOp) {
+  // We need to declare variables at top if the function has multiple blocks.
+  if (!emitter.shouldDeclareVariablesAtTop() &&
+      functionOp.getBlocks().size() > 1) {
+    return functionOp.emitOpError(
+        "with multiple blocks needs variables declared at top");
+  }
+
+  CppEmitter::Scope scope(emitter);
+  raw_indented_ostream &os = emitter.ostream();
+
+  if (functionOp->hasAttr("msl_kernel")) {
+    os << "kernel ";
+  }
+
+  if (failed(emitter.emitTypes(functionOp.getLoc(),
+                               functionOp.getFunctionType().getResults())))
+    return failure();
+  os << " " << functionOp.getName();
+
+  os << "(";
+  if (failed(interleaveCommaWithError(
+          functionOp.getArguments(), os,
+          [&](BlockArgument arg) -> LogicalResult {
+            if (failed(emitter.emitType(functionOp.getLoc(), arg.getType())))
+              return failure();
+            os << " " << emitter.getOrCreateName(arg);
+
+            // Assume we only have one argument here
+            for (auto attr : functionOp.getArgAttrs(arg.getArgNumber())) {
+              if (attr.getName().strref().startswith("emitc.")) {
+                // Assume attributes are units only for now
+                os << " [[";
+                os << attr.getName().strref().substr(6);
+                os << "]]";
+              }
+            }
+            return success();
+          })))
+    return failure();
+  os << ") {\n";
+  os.indent();
+  if (emitter.shouldDeclareVariablesAtTop()) {
+    // Declare all variables that hold op results including those from nested
+    // regions.
+    WalkResult result =
+        functionOp.walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+          for (OpResult result : op->getResults()) {
+            if (failed(emitter.emitVariableDeclaration(
+                    result, /*trailingSemicolon=*/true))) {
+              return WalkResult(
+                  op->emitError("unable to declare result variable for op"));
+            }
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted())
+      return failure();
+  }
+
+  Region::BlockListType &blocks = functionOp.getBlocks();
+  // Create label names for basic blocks.
+  for (Block &block : blocks) {
+    emitter.getOrCreateName(block);
+  }
+
+  // Declare variables for basic block arguments.
+  for (auto it = std::next(blocks.begin()); it != blocks.end(); ++it) {
+    Block &block = *it;
+    for (BlockArgument &arg : block.getArguments()) {
+      if (emitter.hasValueInScope(arg))
+        return functionOp.emitOpError(" block argument #")
+               << arg.getArgNumber() << " is out of scope";
+      if (failed(
+              emitter.emitType(block.getParentOp()->getLoc(), arg.getType()))) {
+        return failure();
+      }
+      os << " " << emitter.getOrCreateName(arg) << ";\n";
+    }
+  }
+
+  for (Block &block : blocks) {
+    // Only print a label if the block has predecessors.
+    if (!block.hasNoPredecessors()) {
+      if (failed(emitter.emitLabel(block)))
+        return failure();
+    }
+    for (Operation &op : block.getOperations()) {
+      // When generating code for an scf.if or cf.cond_br op no semicolon needs
+      // to be printed after the closing brace.
+      // When generating code for an scf.for op, printing a trailing semicolon
+      // is handled within the printOperation function.
+      bool trailingSemicolon =
+          !isa<scf::IfOp, scf::ForOp, cf::CondBranchOp>(op);
+
+      if (failed(emitter.emitOperation(
+              op, /*trailingSemicolon=*/trailingSemicolon)))
+        return failure();
+    }
+  }
+  os.unindent() << "}\n";
+  return success();
+}
+
+CppEmitter::CppEmitter(raw_ostream &os, bool declareVariablesAtTop)
+    : os(os), declareVariablesAtTop(declareVariablesAtTop) {
+  valueInScopeCount.push(0);
+  labelInScopeCount.push(0);
+}
+
+/// Return the existing or a new name for a Value.
+StringRef CppEmitter::getOrCreateName(Value val) {
+  if (!valueMapper.count(val))
+    valueMapper.insert(val, formatv("v{0}", ++valueInScopeCount.top()));
+  return *valueMapper.begin(val);
+}
+
+/// Return the existing or a new label for a Block.
+StringRef CppEmitter::getOrCreateName(Block &block) {
+  if (!blockMapper.count(&block))
+    blockMapper.insert(&block, formatv("label{0}", ++labelInScopeCount.top()));
+  return *blockMapper.begin(&block);
+}
+
+bool CppEmitter::shouldMapToUnsigned(IntegerType::SignednessSemantics val) {
+  switch (val) {
+  case IntegerType::Signless:
+    return false;
+  case IntegerType::Signed:
+    return false;
+  case IntegerType::Unsigned:
+    return true;
+  }
+  llvm_unreachable("Unexpected IntegerType::SignednessSemantics");
+}
+
+bool CppEmitter::hasValueInScope(Value val) { return valueMapper.count(val); }
+
+bool CppEmitter::hasBlockLabel(Block &block) {
+  return blockMapper.count(&block);
+}
+
+LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
+  auto printInt = [&](const APInt &val, bool isUnsigned) {
+    if (val.getBitWidth() == 1) {
+      if (val.getBoolValue())
+        os << "true";
+      else
+        os << "false";
+    } else {
+      SmallString<128> strValue;
+      val.toString(strValue, 10, !isUnsigned, false);
+      os << strValue;
+    }
+  };
+
+  auto printFloat = [&](const APFloat &val) {
+    if (val.isFinite()) {
+      SmallString<128> strValue;
+      // Use default values of toString except don't truncate zeros.
+      val.toString(strValue, 0, 0, false);
+      switch (llvm::APFloatBase::SemanticsToEnum(val.getSemantics())) {
+      case llvm::APFloatBase::S_IEEEsingle:
+        os << "(float)";
+        break;
+      case llvm::APFloatBase::S_IEEEdouble:
+        os << "(double)";
+        break;
+      default:
+        break;
+      };
+      os << strValue;
+    } else if (val.isNaN()) {
+      os << "NAN";
+    } else if (val.isInfinity()) {
+      if (val.isNegative())
+        os << "-";
+      os << "INFINITY";
+    }
+  };
+
+  // Print floating point attributes.
+  if (auto fAttr = attr.dyn_cast<FloatAttr>()) {
+    printFloat(fAttr.getValue());
+    return success();
+  }
+  if (auto dense = attr.dyn_cast<DenseFPElementsAttr>()) {
+    os << '{';
+    interleaveComma(dense, os, [&](const APFloat &val) { printFloat(val); });
+    os << '}';
+    return success();
+  }
+
+  // Print integer attributes.
+  if (auto iAttr = attr.dyn_cast<IntegerAttr>()) {
+    if (auto iType = iAttr.getType().dyn_cast<IntegerType>()) {
+      printInt(iAttr.getValue(), shouldMapToUnsigned(iType.getSignedness()));
+      return success();
+    }
+    if (auto iType = iAttr.getType().dyn_cast<IndexType>()) {
+      printInt(iAttr.getValue(), false);
+      return success();
+    }
+  }
+  if (auto dense = attr.dyn_cast<DenseIntElementsAttr>()) {
+    if (auto iType = dense.getType()
+                         .cast<TensorType>()
+                         .getElementType()
+                         .dyn_cast<IntegerType>()) {
+      os << '{';
+      interleaveComma(dense, os, [&](const APInt &val) {
+        printInt(val, shouldMapToUnsigned(iType.getSignedness()));
+      });
+      os << '}';
+      return success();
+    }
+    if (auto iType = dense.getType()
+                         .cast<TensorType>()
+                         .getElementType()
+                         .dyn_cast<IndexType>()) {
+      os << '{';
+      interleaveComma(dense, os,
+                      [&](const APInt &val) { printInt(val, false); });
+      os << '}';
+      return success();
+    }
+  }
+
+  // Print opaque attributes.
+  if (auto oAttr = attr.dyn_cast<emitc::OpaqueAttr>()) {
+    os << oAttr.getValue();
+    return success();
+  }
+
+  // Print symbolic reference attributes.
+  if (auto sAttr = attr.dyn_cast<SymbolRefAttr>()) {
+    if (sAttr.getNestedReferences().size() > 1)
+      return emitError(loc, "attribute has more than 1 nested reference");
+    os << sAttr.getRootReference().getValue();
+    return success();
+  }
+
+  // Print type attributes.
+  if (auto type = attr.dyn_cast<TypeAttr>())
+    return emitType(loc, type.getValue());
+
+  return emitError(loc, "cannot emit attribute of type ") << attr.getType();
+}
+
+LogicalResult CppEmitter::emitOperands(Operation &op) {
+  auto emitOperandName = [&](Value result) -> LogicalResult {
+    if (!hasValueInScope(result))
+      return op.emitOpError() << "operand value not in scope";
+    os << getOrCreateName(result);
+    return success();
+  };
+  return interleaveCommaWithError(op.getOperands(), os, emitOperandName);
+}
+
+LogicalResult
+CppEmitter::emitOperandsAndAttributes(Operation &op,
+                                      ArrayRef<StringRef> exclude) {
+  if (failed(emitOperands(op)))
+    return failure();
+  // Insert comma in between operands and non-filtered attributes if needed.
+  if (op.getNumOperands() > 0) {
+    for (NamedAttribute attr : op.getAttrs()) {
+      if (!llvm::is_contained(exclude, attr.getName().strref())) {
+        os << ", ";
+        break;
+      }
+    }
+  }
+  // Emit attributes.
+  auto emitNamedAttribute = [&](NamedAttribute attr) -> LogicalResult {
+    if (llvm::is_contained(exclude, attr.getName().strref()))
+      return success();
+    os << "/* " << attr.getName().getValue() << " */";
+    if (failed(emitAttribute(op.getLoc(), attr.getValue())))
+      return failure();
+    return success();
+  };
+  return interleaveCommaWithError(op.getAttrs(), os, emitNamedAttribute);
+}
+
+LogicalResult CppEmitter::emitVariableAssignment(OpResult result) {
+  if (!hasValueInScope(result)) {
+    return result.getDefiningOp()->emitOpError(
+        "result variable for the operation has not been declared");
+  }
+  os << getOrCreateName(result) << " = ";
+  return success();
+}
+
+LogicalResult CppEmitter::emitVariableDeclaration(OpResult result,
+                                                  bool trailingSemicolon) {
+  if (hasValueInScope(result)) {
+    return result.getDefiningOp()->emitError(
+        "result variable for the operation already declared");
+  }
+  if (failed(emitType(result.getOwner()->getLoc(), result.getType())))
+    return failure();
+  os << " " << getOrCreateName(result);
+  if (trailingSemicolon)
+    os << ";\n";
+  return success();
+}
+
+LogicalResult CppEmitter::emitAssignPrefix(Operation &op) {
+  switch (op.getNumResults()) {
+  case 0:
+    break;
+  case 1: {
+    OpResult result = op.getResult(0);
+    if (shouldDeclareVariablesAtTop()) {
+      if (failed(emitVariableAssignment(result)))
+        return failure();
+    } else {
+      if (failed(emitVariableDeclaration(result, /*trailingSemicolon=*/false)))
+        return failure();
+      os << " = ";
+    }
+    break;
+  }
+  default:
+    if (!shouldDeclareVariablesAtTop()) {
+      for (OpResult result : op.getResults()) {
+        if (failed(emitVariableDeclaration(result, /*trailingSemicolon=*/true)))
+          return failure();
+      }
+    }
+    os << "std::tie(";
+    interleaveComma(op.getResults(), os,
+                    [&](Value result) { os << getOrCreateName(result); });
+    os << ") = ";
+  }
+  return success();
+}
+
+LogicalResult CppEmitter::emitLabel(Block &block) {
+  if (!hasBlockLabel(block))
+    return block.getParentOp()->emitError("label for block not found");
+  // FIXME: Add feature in `raw_indented_ostream` to ignore indent for block
+  // label instead of using `getOStream`.
+  os.getOStream() << getOrCreateName(block) << ":\n";
+  return success();
+}
+
+LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
+  LogicalResult status =
+      llvm::TypeSwitch<Operation *, LogicalResult>(&op)
+          // Builtin ops.
+          .Case<ModuleOp>([&](auto op) { return printOperation(*this, op); })
+          // CF ops.
+          .Case<cf::BranchOp, cf::CondBranchOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          // EmitC ops.
+          .Case<emitc::ApplyOp, emitc::CallOp, emitc::CastOp, emitc::ConstantOp,
+                emitc::IncludeOp, emitc::VariableOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          // Func ops.
+          .Case<func::CallOp, func::ConstantOp, func::FuncOp, func::ReturnOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          // SCF ops.
+          .Case<scf::ForOp, scf::IfOp, scf::YieldOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          // Arithmetic ops.
+          .Case<arith::ConstantOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<arith::CmpIOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<arith::IndexCastOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<arith::TruncIOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<arith::AddFOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<vector::ExtractElementOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<rawmem::LoadOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Case<rawmem::StoreOp>(
+              [&](auto op) { return printOperation(*this, op); })
+          .Default([&](Operation *) {
+            return op.emitOpError("unable to find printer for op");
+          });
+
+  if (failed(status))
+    return failure();
+  os << (trailingSemicolon ? ";\n" : "\n");
+  return success();
+}
+
+LogicalResult CppEmitter::emitType(Location loc, Type type) {
+  if (auto vType = type.dyn_cast<VectorType>()) {
+    if (vType.getShape().size() != 1) {
+      return emitError(loc, "only 1-D vectors are supported ") << type;
+    }
+    if (vType.getShape()[0] != 2 && vType.getShape()[0] != 3 &&
+        vType.getShape()[0] != 4) {
+      return emitError(loc, "only vectors of size 2, 3, or 4 are supported ")
+             << type;
+    }
+
+    os << "vec<";
+    auto scalarRes = emitType(loc, vType.getElementType());
+    if (failed(scalarRes)) {
+      return scalarRes;
+    }
+
+    os << ", " << vType.getShape()[0] << ">";
+
+    return success();
+  }
+  if (auto iType = type.dyn_cast<IntegerType>()) {
+    switch (iType.getWidth()) {
+    case 1:
+      return (os << "bool"), success();
+    case 8:
+    case 16:
+    case 32:
+    case 64:
+      if (shouldMapToUnsigned(iType.getSignedness()))
+        return (os << "uint" << iType.getWidth() << "_t"), success();
+      else
+        return (os << "int" << iType.getWidth() << "_t"), success();
+    default:
+      return emitError(loc, "cannot emit integer type ") << type;
+    }
+  }
+  if (auto fType = type.dyn_cast<FloatType>()) {
+    switch (fType.getWidth()) {
+    case 32:
+      return (os << "float"), success();
+    case 64:
+      return (os << "double"), success();
+    default:
+      return emitError(loc, "cannot emit float type ") << type;
+    }
+  }
+  if (auto iType = type.dyn_cast<IndexType>())
+    return (os << "size_t"), success();
+  if (auto tType = type.dyn_cast<TensorType>()) {
+    if (!tType.hasRank())
+      return emitError(loc, "cannot emit unranked tensor type");
+    if (!tType.hasStaticShape())
+      return emitError(loc, "cannot emit tensor type with non static shape");
+    os << "Tensor<";
+    if (failed(emitType(loc, tType.getElementType())))
+      return failure();
+    auto shape = tType.getShape();
+    for (auto dimSize : shape) {
+      os << ", ";
+      os << dimSize;
+    }
+    os << ">";
+    return success();
+  }
+  if (auto tType = type.dyn_cast<TupleType>())
+    return emitTupleType(loc, tType.getTypes());
+  if (auto oType = type.dyn_cast<emitc::OpaqueType>()) {
+    os << oType.getValue();
+    return success();
+  }
+  if (auto pType = type.dyn_cast<emitc::PointerType>()) {
+    if (failed(emitType(loc, pType.getPointee())))
+      return failure();
+    os << "*";
+    return success();
+  }
+  if (auto pType = type.dyn_cast<rawmem::PointerType>()) {
+    switch (pType.getAddressSpace()) {
+    case 0:
+      os << "thread ";
+      break;
+    case 1:
+      os << "device ";
+      break;
+    case 2:
+      os << "constant ";
+      break;
+    case 3:
+      os << "threadgroup ";
+      break;
+    default:
+      return emitError(loc, "failed to legalize address space ") << type;
+    }
+    if (failed(emitType(loc, pType.getElementType())))
+      return failure();
+    os << "*";
+    return success();
+  }
+  return emitError(loc, "cannot emit type ") << type;
+}
+
+LogicalResult CppEmitter::emitTypes(Location loc, ArrayRef<Type> types) {
+  switch (types.size()) {
+  case 0:
+    os << "void";
+    return success();
+  case 1:
+    return emitType(loc, types.front());
+  default:
+    return emitTupleType(loc, types);
+  }
+}
+
+LogicalResult CppEmitter::emitTupleType(Location loc, ArrayRef<Type> types) {
+  os << "std::tuple<";
+  if (failed(interleaveCommaWithError(
+          types, os, [&](Type type) { return emitType(loc, type); })))
+    return failure();
+  os << ">";
+  return success();
+}
+
+LogicalResult lcl::translateToCpp(Operation *op, raw_ostream &os,
+                                  bool declareVariablesAtTop) {
+  CppEmitter emitter(os, declareVariablesAtTop);
+  return emitter.emitOperation(*op, /*trailingSemicolon=*/false);
+}

--- a/src/compiler/VulkanSPVBackendImpl.cpp
+++ b/src/compiler/VulkanSPVBackendImpl.cpp
@@ -40,7 +40,7 @@
 
 namespace lcl {
 namespace detail {
-VulkanSPVBackendImpl::VulkanSPVBackendImpl() : mPM(&mContext) {
+VulkanSPVBackendImpl::VulkanSPVBackendImpl(bool initializeSPV) : mPM(&mContext) {
   mlir::registerAllDialects(mContext);
   mlir::DialectRegistry registry;
   registry.insert<mlir::rawmem::RawMemoryDialect>();
@@ -56,52 +56,40 @@ VulkanSPVBackendImpl::VulkanSPVBackendImpl() : mPM(&mContext) {
   mPM.addPass(lcl::createInferPointerTypesPass());
   // This is supposed to cleanup extra reinterpret_casts
   mPM.addPass(mlir::createCanonicalizerPass());
-  mPM.addPass(lcl::createGPUToSPIRVPass());
-  mPM.addNestedPass<mlir::spirv::ModuleOp>(
-      mlir::spirv::createLowerABIAttributesPass());
-  mPM.addNestedPass<mlir::spirv::ModuleOp>(
-      mlir::spirv::createUpdateVersionCapabilityExtensionPass());
+
+  if (initializeSPV) {
+    mPM.addPass(lcl::createGPUToSPIRVPass());
+    mPM.addNestedPass<mlir::spirv::ModuleOp>(
+        mlir::spirv::createLowerABIAttributesPass());
+    mPM.addNestedPass<mlir::spirv::ModuleOp>(
+        mlir::spirv::createUpdateVersionCapabilityExtensionPass());
+  }
 }
-std::vector<unsigned char>
-VulkanSPVBackendImpl::compile(std::unique_ptr<llvm::Module> module) {
-  if (!module) {
-    llvm::errs() << "INVALID MODULE!!!\n";
-  }
 
-  {
-    // TODO this is an unnecessary hack to avoid support of memrefs of memrefs
-    // in MLIR.
-    using namespace llvm;
-    // Create the analysis managers.
-    LoopAnalysisManager LAM;
-    FunctionAnalysisManager FAM;
-    CGSCCAnalysisManager CGAM;
-    ModuleAnalysisManager MAM;
+void VulkanSPVBackendImpl::prepareLLVMModule(std::unique_ptr<llvm::Module> &module) {
+  // TODO this is an unnecessary hack to avoid support of memrefs of memrefs
+  // in MLIR.
+  using namespace llvm;
 
-    // Create the new pass manager builder.
-    // Take a look at the PassBuilder constructor parameters for more
-    // customization, e.g. specifying a TargetMachine or various debugging
-    // options.
-    PassBuilder PB;
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
 
-    // Register all the basic analyses with the managers.
-    PB.registerModuleAnalyses(MAM);
-    PB.registerCGSCCAnalyses(CGAM);
-    PB.registerFunctionAnalyses(FAM);
-    PB.registerLoopAnalyses(LAM);
-    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+  PassBuilder PB;
 
-    // Create the pass manager.
-    // This one corresponds to a typical -O2 optimization pipeline.
-    ModulePassManager MPM =
-        PB.buildPerModuleDefaultPipeline(OptimizationLevel::O2);
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
-    // Optimize the IR!
-    MPM.run(*module, MAM);
-  }
+  ModulePassManager MPM =
+      PB.buildPerModuleDefaultPipeline(OptimizationLevel::O2);
 
-  // TODO only print conditionally
-  {
+  MPM.run(*module, MAM);
+
+  if (mHasLLVMPrinter) {
     llvm::SmallVector<char, 10000> buffer;
     llvm::BitcodeWriter writer(buffer);
     writer.writeModule(*module);
@@ -109,20 +97,23 @@ VulkanSPVBackendImpl::compile(std::unique_ptr<llvm::Module> module) {
     std::span<char> res{buffer.begin(), buffer.end()};
     mLLVMIRPrinter(res);
   }
-  {
+  if (mHasLLVMTextPrinter) {
     std::string res;
     llvm::raw_string_ostream os{res};
     module->print(os, nullptr);
     os.flush();
     mLLVMTextPrinter(res);
   }
+}
 
+mlir::OwningOpRef<mlir::ModuleOp> VulkanSPVBackendImpl::convertLLVMIRToMLIR(std::unique_ptr<llvm::Module> &module) {
   auto clone = llvm::CloneModule(*module);
   auto mlirModule = mlir::translateLLVMIRToModule(std::move(clone), &mContext);
 
   // TODO check result
   mPM.run(mlirModule.get());
 
+  // TODO make conditional
   {
     std::string res;
     llvm::raw_string_ostream os{res};
@@ -131,12 +122,16 @@ VulkanSPVBackendImpl::compile(std::unique_ptr<llvm::Module> module) {
     mMLIRPrinter(res);
   }
 
+  return mlirModule;
+}
+
+std::vector<unsigned char> VulkanSPVBackendImpl::convertMLIRToSPIRV(mlir::OwningOpRef<mlir::ModuleOp> &mlirModule) {
   llvm::SmallVector<uint32_t, 10000> binary;
 
   auto spvModule =
       mlirModule->lookupSymbol<mlir::spirv::ModuleOp>("__spv__ocl_program");
-  mlir::spirv::serialize(spvModule, binary);
 
+  // TODO check result
   mlir::spirv::serialize(spvModule, binary);
 
   std::vector<unsigned char> resBinary;
@@ -144,6 +139,19 @@ VulkanSPVBackendImpl::compile(std::unique_ptr<llvm::Module> module) {
   std::memcpy(resBinary.data(), binary.data(), resBinary.size());
 
   { mSPVPrinter(resBinary); }
+}
+
+std::vector<unsigned char>
+VulkanSPVBackendImpl::compile(std::unique_ptr<llvm::Module> module) {
+  if (!module) {
+    llvm::errs() << "INVALID MODULE!!!\n";
+    // TODO return error instead.
+    std::terminate();
+  }
+
+  prepareLLVMModule(module);
+  auto mlirModule = convertLLVMIRToMLIR(module);
+  auto resBinary = convertMLIRToSPIRV(mlirModule);
 
   return resBinary;
 }

--- a/src/compiler/VulkanSPVBackendImpl.cpp
+++ b/src/compiler/VulkanSPVBackendImpl.cpp
@@ -40,7 +40,8 @@
 
 namespace lcl {
 namespace detail {
-VulkanSPVBackendImpl::VulkanSPVBackendImpl(bool initializeSPV) : mPM(&mContext) {
+VulkanSPVBackendImpl::VulkanSPVBackendImpl(bool initializeSPV)
+    : mPM(&mContext) {
   mlir::registerAllDialects(mContext);
   mlir::DialectRegistry registry;
   registry.insert<mlir::rawmem::RawMemoryDialect>();
@@ -66,7 +67,8 @@ VulkanSPVBackendImpl::VulkanSPVBackendImpl(bool initializeSPV) : mPM(&mContext) 
   }
 }
 
-void VulkanSPVBackendImpl::prepareLLVMModule(std::unique_ptr<llvm::Module> &module) {
+void VulkanSPVBackendImpl::prepareLLVMModule(
+    std::unique_ptr<llvm::Module> &module) {
   // TODO this is an unnecessary hack to avoid support of memrefs of memrefs
   // in MLIR.
   using namespace llvm;
@@ -106,7 +108,8 @@ void VulkanSPVBackendImpl::prepareLLVMModule(std::unique_ptr<llvm::Module> &modu
   }
 }
 
-mlir::OwningOpRef<mlir::ModuleOp> VulkanSPVBackendImpl::convertLLVMIRToMLIR(std::unique_ptr<llvm::Module> &module) {
+mlir::OwningOpRef<mlir::ModuleOp> VulkanSPVBackendImpl::convertLLVMIRToMLIR(
+    std::unique_ptr<llvm::Module> &module) {
   auto clone = llvm::CloneModule(*module);
   auto mlirModule = mlir::translateLLVMIRToModule(std::move(clone), &mContext);
 
@@ -125,7 +128,8 @@ mlir::OwningOpRef<mlir::ModuleOp> VulkanSPVBackendImpl::convertLLVMIRToMLIR(std:
   return mlirModule;
 }
 
-std::vector<unsigned char> VulkanSPVBackendImpl::convertMLIRToSPIRV(mlir::OwningOpRef<mlir::ModuleOp> &mlirModule) {
+std::vector<unsigned char> VulkanSPVBackendImpl::convertMLIRToSPIRV(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlirModule) {
   llvm::SmallVector<uint32_t, 10000> binary;
 
   auto spvModule =

--- a/src/compiler/VulkanSPVBackendImpl.hpp
+++ b/src/compiler/VulkanSPVBackendImpl.hpp
@@ -58,8 +58,10 @@ public:
 
 protected:
   void prepareLLVMModule(std::unique_ptr<llvm::Module> &module);
-  mlir::OwningOpRef<mlir::ModuleOp> convertLLVMIRToMLIR(std::unique_ptr<llvm::Module> &module);
-  std::vector<unsigned char> convertMLIRToSPIRV(mlir::OwningOpRef<mlir::ModuleOp> &mlirModule);
+  mlir::OwningOpRef<mlir::ModuleOp>
+  convertLLVMIRToMLIR(std::unique_ptr<llvm::Module> &module);
+  std::vector<unsigned char>
+  convertMLIRToSPIRV(mlir::OwningOpRef<mlir::ModuleOp> &mlirModule);
 
   mlir::MLIRContext mContext;
   mlir::PassManager mPM;

--- a/src/compiler/passes/mlir/AIRKernelABIPass.cpp
+++ b/src/compiler/passes/mlir/AIRKernelABIPass.cpp
@@ -6,9 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "RawMemory/RawMemoryTypes.h"
+#include "RawMemory/RawMemoryOps.h"
 #include "passes.hpp"
 
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -18,88 +21,97 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace {
+template <typename FuncTy>
+static void processFunction(FuncTy func) {
+  mlir::OpBuilder builder{func};
+
+  auto oldType = func.getFunctionType();
+  auto retType = func.getResultTypes();
+
+  // TODO convert scalar types to pointers
+  llvm::SmallVector<mlir::Type, 8> argTypes;
+
+  for (auto &argType : llvm::enumerate(oldType.getInputs())) {
+    if (std::is_same_v<FuncTy, mlir::gpu::GPUFuncOp> &&
+        !argType.value().template isa<mlir::rawmem::PointerType>()) {
+
+      mlir::OpBuilder::InsertionGuard _{builder};
+      builder.setInsertionPointToStart(&func.getBody().front());
+
+      mlir::Type ptrType =
+          mlir::rawmem::PointerType::get(argType.value(), 1);
+      argTypes.push_back(ptrType);
+
+      if (func.isDeclaration() || func.getBody().empty()) {
+        continue;
+      }
+
+      func.getBody().front().getArgument(argType.index()).setType(ptrType);
+
+      auto load = builder.create<mlir::rawmem::LoadOp>(
+          builder.getUnknownLoc(), func.getArgument(argType.index()));
+
+      func.getArgument(argType.index()).replaceAllUsesExcept(load, {load});
+    } else {
+      argTypes.push_back(argType.value());
+    }
+  }
+
+  mlir::Type indexType = mlir::VectorType::get({3}, builder.getI32Type(), 0);
+
+  for (int i = 0; i < 4; i++) {
+    argTypes.push_back(indexType);
+  }
+
+  auto newFuncType =
+      mlir::FunctionType::get(func.getContext(), argTypes, retType);
+
+  if constexpr (std::is_same_v<mlir::gpu::GPUFuncOp, FuncTy>) {
+    func.function_typeAttr(mlir::TypeAttr::get(newFuncType));
+  } else if constexpr (std::is_same_v<mlir::func::FuncOp, FuncTy>) {
+    func.setFunctionTypeAttr(mlir::TypeAttr::get(newFuncType));
+  }
+
+  if (func.isDeclaration() || func.getBody().empty()) {
+    return;
+  }
+
+  for (int i = 0; i < 4; i++)
+    func.getBody().getBlocks().front().addArgument(indexType,
+                                                   builder.getUnknownLoc());
+
+  llvm::SmallVector<mlir::Value, 4> newVals;
+  for (unsigned int i = newFuncType.getNumInputs() - 4;
+       i < newFuncType.getNumInputs(); i++) {
+    newVals.push_back(func.getArgument(i));
+  }
+  func.walk([&](mlir::func::CallOp call) {
+    call->insertOperands(call->getNumOperands(), newVals);
+  });
+}
+
 struct AIRKernelABIPass
     : public mlir::PassWrapper<AIRKernelABIPass,
-                               mlir::OperationPass<mlir::LLVM::LLVMFuncOp>> {
+                               mlir::OperationPass<mlir::gpu::GPUModuleOp>> {
+
+  static constexpr ::llvm::StringLiteral getArgumentName() {
+    return ::llvm::StringLiteral("air-kernel-abi");
+  }
+  ::llvm::StringRef getArgument() const override { return "air-kernel-abi"; }
+
+  ::llvm::StringRef getDescription() const override { return "Rewrite functions honoring Metal Shading Language ABI"; }
+
   void runOnOperation() override {
-    mlir::LLVM::LLVMFuncOp func = getOperation();
+    mlir::gpu::GPUModuleOp module = getOperation();
 
-    if (func.getCConv() != mlir::LLVM::CConv::SPIR_FUNC &&
-        func.getCConv() != mlir::LLVM::CConv::SPIR_KERNEL) {
-      return;
-    }
-
-    mlir::OpBuilder builder{func};
-
-    auto oldType = func.getFunctionType();
-    auto retType = func.getResultTypes();
-
-    // TODO convert scalar types to pointers
-    llvm::SmallVector<mlir::Type, 8> argTypes;
-
-    for (auto &argType : llvm::enumerate(oldType.params())) {
-      if (func.getCConv() == mlir::LLVM::CConv::SPIR_KERNEL &&
-          !argType.value().isa<mlir::LLVM::LLVMPointerType>()) {
-        mlir::OpBuilder::InsertionGuard _{builder};
-        builder.setInsertionPointToStart(&func.getBody().front());
-
-        mlir::Type ptrType =
-            mlir::LLVM::LLVMPointerType::get(argType.value(), 1);
-        argTypes.push_back(ptrType);
-
-        if (func.isDeclaration() || func.getBody().empty()) {
-          continue;
-        }
-        func.getBody().front().getArgument(argType.index()).setType(ptrType);
-
-        auto load = builder.create<mlir::LLVM::LoadOp>(
-            builder.getUnknownLoc(), func.getArgument(argType.index()));
-
-        func.getArgument(argType.index()).replaceAllUsesExcept(load, {load});
-      } else {
-        argTypes.push_back(argType.value());
-      }
-    }
-
-    mlir::Type indexType = mlir::VectorType::get({3}, builder.getI32Type(), 0);
-
-    for (int i = 0; i < 4; i++) {
-      argTypes.push_back(indexType);
-    }
-
-    // func.getBody().front().getArgument(0).replaceAllUsesExcept()
-
-    auto newFuncType =
-        mlir::LLVM::LLVMFunctionType::get(retType.front(), argTypes);
-
-    func.setFunctionTypeAttr(mlir::TypeAttr::get(newFuncType));
-
-    if (func.isDeclaration() || func.getBody().empty()) {
-      return;
-    }
-
-    for (int i = 0; i < 4; i++)
-      func.getBody().getBlocks().front().addArgument(indexType,
-                                                     builder.getUnknownLoc());
-
-    llvm::SmallVector<mlir::Value, 4> newVals;
-    for (unsigned int i = newFuncType.getNumParams() - 4;
-         i < newFuncType.getNumParams(); i++) {
-      newVals.push_back(func.getArgument(i));
-    }
-    func.walk([&](mlir::LLVM::CallOp call) {
-      if (!call.getCallee().hasValue())
-        return;
-      mlir::LLVM::LLVMFuncOp callee = llvm::cast<mlir::LLVM::LLVMFuncOp>(
-          func->getParentOfType<mlir::ModuleOp>().lookupSymbol(
-              call.getCallee().getValue()));
-      if (callee.getCConv() != mlir::LLVM::CConv::SPIR_FUNC &&
-          callee.getCConv() != mlir::LLVM::CConv::SPIR_KERNEL) {
-        return;
-      }
-      call->insertOperands(call->getNumOperands(), newVals);
+    module.walk([](mlir::gpu::GPUFuncOp func) {
+      processFunction(func);
+    });
+    module.walk([](mlir::func::FuncOp func) {
+      processFunction(func);
     });
   }
 };

--- a/src/compiler/passes/mlir/AIRKernelABIPass.cpp
+++ b/src/compiler/passes/mlir/AIRKernelABIPass.cpp
@@ -6,26 +6,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "RawMemory/RawMemoryTypes.h"
 #include "RawMemory/RawMemoryOps.h"
+#include "RawMemory/RawMemoryTypes.h"
 #include "passes.hpp"
 
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SmallVector.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace {
-template <typename FuncTy>
-static void processFunction(FuncTy func) {
+template <typename FuncTy> static void processFunction(FuncTy func) {
   mlir::OpBuilder builder{func};
 
   auto oldType = func.getFunctionType();
@@ -41,8 +40,7 @@ static void processFunction(FuncTy func) {
       mlir::OpBuilder::InsertionGuard _{builder};
       builder.setInsertionPointToStart(&func.getBody().front());
 
-      mlir::Type ptrType =
-          mlir::rawmem::PointerType::get(argType.value(), 1);
+      mlir::Type ptrType = mlir::rawmem::PointerType::get(argType.value(), 1);
       argTypes.push_back(ptrType);
 
       if (func.isDeclaration() || func.getBody().empty()) {
@@ -102,17 +100,15 @@ struct AIRKernelABIPass
   }
   ::llvm::StringRef getArgument() const override { return "air-kernel-abi"; }
 
-  ::llvm::StringRef getDescription() const override { return "Rewrite functions honoring Metal Shading Language ABI"; }
+  ::llvm::StringRef getDescription() const override {
+    return "Rewrite functions honoring Metal Shading Language ABI";
+  }
 
   void runOnOperation() override {
     mlir::gpu::GPUModuleOp module = getOperation();
 
-    module.walk([](mlir::gpu::GPUFuncOp func) {
-      processFunction(func);
-    });
-    module.walk([](mlir::func::FuncOp func) {
-      processFunction(func);
-    });
+    module.walk([](mlir::gpu::GPUFuncOp func) { processFunction(func); });
+    module.walk([](mlir::func::FuncOp func) { processFunction(func); });
   }
 };
 } // namespace

--- a/src/compiler/passes/mlir/CMakeLists.txt
+++ b/src/compiler/passes/mlir/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(LCLPasses STATIC
   ExpandOpenCLFunctionsPass.cpp
   GPUToSPIRVPass.cpp
   InferPointerTypesPass.cpp
+  ExpandGPUBuiltins.cpp
   )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/src/compiler/passes/mlir/CMakeLists.txt
+++ b/src/compiler/passes/mlir/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(LCLPasses STATIC
   GPUToSPIRVPass.cpp
   InferPointerTypesPass.cpp
   ExpandGPUBuiltins.cpp
+  GPUToCppPass.cpp
   )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/src/compiler/passes/mlir/CMakeLists.txt
+++ b/src/compiler/passes/mlir/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(LCLPasses STATIC
+  AIRKernelABIPass.cpp
+  SPIRToGPUConversion.cpp
+  ExpandOpenCLFunctionsPass.cpp
+  GPUToSPIRVPass.cpp
+  InferPointerTypesPass.cpp
+  )
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+list(APPEND CMAKE_MODULE_PATH
+  "${PROJECT_SOURCE_DIR}/third_party/llvm-project/llvm/cmake/modules")
+
+include(AddLLVM)
+
+target_include_directories(LCLPasses SYSTEM PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${MLIR_INCLUDE_DIRS}
+  )
+target_include_directories(LCLPasses PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../dialects/
+  ${CMAKE_CURRENT_BINARY_DIR}/../../dialects
+  )
+
+target_link_libraries(LCLPasses PRIVATE
+  ${dialect_libs}
+  ${conversion_libs}
+  )

--- a/src/compiler/passes/mlir/ExpandGPUBuiltins.cpp
+++ b/src/compiler/passes/mlir/ExpandGPUBuiltins.cpp
@@ -1,0 +1,114 @@
+//===- ExpandGPUBuiltins.cpp ------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "passes.hpp"
+
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+struct GloaglIDPattern : public OpConversionPattern<gpu::GlobalIdOp> {
+  using Base = OpConversionPattern<gpu::GlobalIdOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::GlobalIdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value gidArg;
+    auto parent = op->getParentOfType<func::FuncOp>();
+    if (parent) {
+      // TODO replace 4 with a constant
+      gidArg = parent.getArgument(parent.getNumArguments() - 4);
+    }
+
+    if (!gidArg)
+      return failure();
+
+    // TODO support gpu functions (in case of inlining)
+
+    Value id;
+
+    switch (op.dimension()) {
+    case gpu::Dimension::x:
+      id = rewriter.create<arith::ConstantOp>(op.getLoc(),
+                                              rewriter.getIndexAttr(0));
+      break;
+    case gpu::Dimension::y:
+      id = rewriter.create<arith::ConstantOp>(op.getLoc(),
+                                              rewriter.getIndexAttr(1));
+      break;
+    case gpu::Dimension::z:
+      id = rewriter.create<arith::ConstantOp>(op.getLoc(),
+                                              rewriter.getIndexAttr(2));
+      break;
+    }
+
+    Value extracted =
+        rewriter.create<vector::ExtractElementOp>(op.getLoc(), gidArg, id);
+    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, rewriter.getIndexType(),
+                                                    extracted);
+
+    return success();
+  }
+};
+
+struct ExpandGPUBuiltinsPass
+    : public mlir::PassWrapper<ExpandGPUBuiltinsPass,
+                               OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpandGPUBuiltinsPass);
+
+  static constexpr llvm::StringLiteral getArgumentName() {
+    return llvm::StringLiteral("expand-gpu-builtins");
+  }
+  llvm::StringRef getArgument() const override { return "expand-gpu-builtins"; }
+
+  llvm::StringRef getDescription() const override {
+    return "Expand GPU dialect operations for Metal Shading Language";
+  }
+
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<arith::ArithmeticDialect>();
+    registry.insert<vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    TypeConverter typeConverter{};
+    typeConverter.addConversion([](Type type) { return type; });
+
+    ConversionTarget target{getContext()};
+    target.addIllegalOp<mlir::gpu::GlobalIdOp>();
+    target.addLegalDialect<vector::VectorDialect>();
+    target.addLegalDialect<arith::ArithmeticDialect>();
+
+    RewritePatternSet patterns{&getContext()};
+    patterns.add<GloaglIDPattern>(typeConverter, patterns.getContext());
+
+    ModuleOp module = getOperation();
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+namespace lcl {
+std::unique_ptr<mlir::Pass> createExpandGPUBuiltinsPass() {
+  return std::make_unique<ExpandGPUBuiltinsPass>();
+}
+} // namespace lcl

--- a/src/compiler/passes/mlir/GPUToCppPass.cpp
+++ b/src/compiler/passes/mlir/GPUToCppPass.cpp
@@ -1,0 +1,137 @@
+//===- GPUToCppPass.cpp -----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "passes.hpp"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+struct GPUReturnPattern : public OpConversionPattern<gpu::ReturnOp> {
+  using Base = OpConversionPattern<gpu::ReturnOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<func::ReturnOp>(op);
+
+    return success();
+  }
+};
+struct GPUFuncPattern : public OpConversionPattern<gpu::GPUFuncOp> {
+  using Base = OpConversionPattern<gpu::GPUFuncOp>;
+  using Base::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::GPUFuncOp func, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto fnType = func.getFunctionType();
+
+    TypeConverter::SignatureConversion signatureConverter(
+        fnType.getNumInputs());
+    {
+      for (const auto &argType : enumerate(fnType.getInputs())) {
+        signatureConverter.addInputs(argType.index(), argType.value());
+      }
+    }
+
+    auto newFuncOp =
+        rewriter.create<func::FuncOp>(func.getLoc(), func.getName(), fnType);
+    newFuncOp.getBody().getBlocks().splice(newFuncOp.end(),
+                                           func.getBody().getBlocks());
+
+    newFuncOp->setAttr("msl_kernel", rewriter.getUnitAttr());
+
+    for (size_t i = 0; i < fnType.getNumInputs(); i++) {
+      newFuncOp.setArgAttrs(i, func.getArgAttrs(i));
+    }
+
+    rewriter.inlineRegionBefore(func.getBody(), newFuncOp.getBody(),
+                                newFuncOp.end());
+    if (failed(rewriter.convertRegionTypes(
+            &newFuncOp.getBody(), *getTypeConverter(), &signatureConverter)))
+      return failure();
+
+    rewriter.eraseOp(func);
+
+    return success();
+  }
+};
+
+struct GPUToCppPass
+    : public PassWrapper<GPUToCppPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GPUToCppPass);
+
+  static constexpr llvm::StringLiteral getArgumentName() {
+    return llvm::StringLiteral("convert-gpu-to-cpp");
+  }
+  llvm::StringRef getArgument() const override { return "convert-gpu-to-cpp"; }
+
+  llvm::StringRef getDescription() const override {
+    return "Convert MLIR GPU dialect to EmitC";
+  }
+
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<func::FuncDialect>();
+    registry.insert<emitc::EmitCDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp module = getOperation();
+
+    OpBuilder builder(context);
+
+    builder.setInsertionPointToStart(module.getBody());
+
+    builder.create<emitc::IncludeOp>(builder.getUnknownLoc(), "metal_stdlib",
+                                     true);
+    builder.create<emitc::IncludeOp>(builder.getUnknownLoc(), "simd/simd.h",
+                                     true);
+
+    module.walk([&builder](gpu::GPUModuleOp moduleOp) {
+      moduleOp.walk([&builder, &moduleOp](func::FuncOp func) {
+        builder.setInsertionPoint(moduleOp.getOperation());
+        builder.clone(*func.getOperation());
+      });
+      moduleOp.walk([&builder, &moduleOp](gpu::GPUFuncOp func) {
+        builder.setInsertionPoint(moduleOp.getOperation());
+        builder.clone(*func.getOperation());
+      });
+      moduleOp.erase();
+    });
+
+    TypeConverter typeConverter{};
+    typeConverter.addConversion([](Type type) { return type; });
+
+    ConversionTarget target{getContext()};
+    target.addIllegalOp<mlir::gpu::GPUFuncOp>();
+    target.addLegalDialect<func::FuncDialect>();
+
+    RewritePatternSet patterns{&getContext()};
+    patterns.add<GPUFuncPattern, GPUReturnPattern>(typeConverter,
+                                                   patterns.getContext());
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> lcl::createGPUToCppPass() {
+  return std::make_unique<GPUToCppPass>();
+}

--- a/src/compiler/passes/mlir/passes.hpp
+++ b/src/compiler/passes/mlir/passes.hpp
@@ -35,4 +35,5 @@ std::unique_ptr<mlir::Pass> createExpandOpenCLFunctionsPass();
 std::unique_ptr<mlir::Pass> createGPUToSPIRVPass();
 std::unique_ptr<mlir::Pass> createInferPointerTypesPass();
 std::unique_ptr<mlir::Pass> createExpandGPUBuiltinsPass();
+std::unique_ptr<mlir::Pass> createGPUToCppPass();
 }

--- a/src/compiler/passes/mlir/passes.hpp
+++ b/src/compiler/passes/mlir/passes.hpp
@@ -34,4 +34,5 @@ std::unique_ptr<mlir::Pass> createAIRKernelABIPass();
 std::unique_ptr<mlir::Pass> createExpandOpenCLFunctionsPass();
 std::unique_ptr<mlir::Pass> createGPUToSPIRVPass();
 std::unique_ptr<mlir::Pass> createInferPointerTypesPass();
+std::unique_ptr<mlir::Pass> createExpandGPUBuiltinsPass();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+list(APPEND CMAKE_MODULE_PATH
+  "${PROJECT_SOURCE_DIR}/third_party/llvm-project/llvm/cmake/modules")
+
+include(AddLLVM)
+
+configure_lit_site_cfg(
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+        MAIN_CONFIG
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+set(LCL_TEST_DEPENDS
+        FileCheck count not
+        lcl-opt
+        lcloc
+        )
+
+add_lit_testsuite(check-lcl "Running the standalone regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${LCL_TEST_DEPENDS}
+  )
+set_target_properties(check-lcl PROPERTIES FOLDER "Tests")
+add_lit_testsuites(LCL ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${LCL_TEST_DEPENDS})
+

--- a/test/compiler/metal/vector_add_msl.cl
+++ b/test/compiler/metal/vector_add_msl.cl
@@ -1,0 +1,101 @@
+// RUN: lcloc --stage=msl --target=metal-ios %s | FileCheck %s
+
+__kernel void vectorAdd(__global float *a, __global float *b, __global float *c, const unsigned int n) {
+  int id = get_global_id(0);
+
+  if (id < n) {
+    c[id] = a[id] + b[id];
+  }
+}
+
+// CHECK: #include <metal_stdlib>
+// CHECK-NEXT: #include <simd/simd.h>
+// CHECK-NEXT:  int64_t _Z13get_global_idj(int32_t v1, vec<int32_t, 3> v2, vec<int32_t, 3> v3, vec<int32_t, 3> v4, vec<int32_t, 3> v5) {
+// CHECK-NEXT:    size_t v6;
+// CHECK-NEXT:    size_t v7;
+// CHECK-NEXT:    size_t v8;
+// CHECK-NEXT:    int32_t v9;
+// CHECK-NEXT:    int32_t v10;
+// CHECK-NEXT:    int32_t v11;
+// CHECK-NEXT:    bool v12;
+// CHECK-NEXT:    bool v13;
+// CHECK-NEXT:    bool v14;
+// CHECK-NEXT:    int32_t v15;
+// CHECK-NEXT:    size_t v16;
+// CHECK-NEXT:    int64_t v17;
+// CHECK-NEXT:    size_t v18;
+// CHECK-NEXT:    size_t v19;
+// CHECK-NEXT:    v6 = 2;
+// CHECK-NEXT:    v7 = 1;
+// CHECK-NEXT:    v8 = 0;
+// CHECK-NEXT:    v9 = 2;
+// CHECK-NEXT:    v10 = 1;
+// CHECK-NEXT:    v11 = 0;
+// CHECK-NEXT:    v12 = v1 == v11;
+// CHECK-NEXT:    if (v12) {
+// CHECK-NEXT:      v18 = v8;
+// CHECK-NEXT:      goto label4;
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      goto label2;
+// CHECK-NEXT:    }
+// CHECK-NEXT:  label2:
+// CHECK-NEXT:    v13 = v1 == v10;
+// CHECK-NEXT:    if (v13) {
+// CHECK-NEXT:      v18 = v7;
+// CHECK-NEXT:      goto label4;
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      goto label3;
+// CHECK-NEXT:    }
+// CHECK-NEXT:  label3:
+// CHECK-NEXT:    v14 = v1 == v9;
+// CHECK-NEXT:    if (v14) {
+// CHECK-NEXT:      v18 = v6;
+// CHECK-NEXT:      goto label4;
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      v19 = v8;
+// CHECK-NEXT:      goto label5;
+// CHECK-NEXT:    }
+// CHECK-NEXT:  label4:
+// CHECK-NEXT:    v15 = v2[v18];
+// CHECK-NEXT:    v16 = (size_t) v15;
+// CHECK-NEXT:    v19 = v16;
+// CHECK-NEXT:    goto label5;
+// CHECK-NEXT:  label5:
+// CHECK-NEXT:    v17 = (int64_t) v19;
+// CHECK-NEXT:    return v17;
+// CHECK-NEXT:  }
+
+// CHECK-NEXT:  kernel void vectorAdd(device float* v1, device float* v2, device float* v3, device int32_t* v4, vec<int32_t, 3> v5 [[thread_position_in_grid]], vec<int32_t, 3> v6 [[thread_position_in_threadgroup]], vec<int32_t, 3> v7 [[threads_per_threadgroup]], vec<int32_t, 3> v8 [[threadgroups_per_grid]]) {
+// CHECK-NEXT:    int32_t v9;
+// CHECK-NEXT:    int32_t v10;
+// CHECK-NEXT:    int64_t v11;
+// CHECK-NEXT:    int32_t v12;
+// CHECK-NEXT:    bool v13;
+// CHECK-NEXT:    size_t v14;
+// CHECK-NEXT:    float v15;
+// CHECK-NEXT:    size_t v16;
+// CHECK-NEXT:    float v17;
+// CHECK-NEXT:    float v18;
+// CHECK-NEXT:    size_t v19;
+// CHECK-NEXT:    v9 = 0;
+// CHECK-NEXT:    v10 = v4[0;
+// CHECK-NEXT:    v11 = _Z13get_global_idj(v9, v5, v6, v7, v8);
+// CHECK-NEXT:    v12 = (int32_t) v11;
+// CHECK-NEXT:    v13 = v12 <= v10;
+// CHECK-NEXT:    if (v13) {
+// CHECK-NEXT:      goto label2;
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      goto label3;
+// CHECK-NEXT:    }
+// CHECK-NEXT:  label2:
+// CHECK-NEXT:    v14 = (size_t) v12;
+// CHECK-NEXT:    v15 = v1[v14];
+// CHECK-NEXT:    v16 = (size_t) v12;
+// CHECK-NEXT:    v17 = v2[v16];
+// CHECK-NEXT:    v18 = v15 + v17;
+// CHECK-NEXT:    v19 = (size_t) v12;
+// CHECK-NEXT:    v3[v19] = v18;
+// CHECK-NEXT:    goto label3;
+// CHECK-NEXT:  label3:
+// CHECK-NEXT:    return;
+// CHECK-NEXT:  }

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -1,0 +1,58 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'LIBRECL'
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.mlir']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.lcl_obj_root, 'test')
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+
+llvm_config.with_system_environment(
+    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.lcl_obj_root, 'test')
+config.lcl_tools_dir = os.path.join(config.lcl_obj_root, 'bin')
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+
+tool_dirs = [config.lcl_tools_dir, config.llvm_tools_dir]
+tools = [
+    'lcl-opt',
+    'lcloc',
+]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)
+

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -1,0 +1,14 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.mlir_obj_dir = "@MLIR_BINARY_DIR@"
+config.python_executable = "@Python3_EXECUTABLE@"
+config.lcl_src_root = "@CMAKE_SOURCE_DIR@"
+config.lcl_obj_root = "@CMAKE_BINARY_DIR@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/test/lit.cfg.py")

--- a/test/transforms/metal/air_abi.mlir
+++ b/test/transforms/metal/air_abi.mlir
@@ -1,0 +1,53 @@
+// RUN: lcl-opt --air-kernel-abi %s | FileCheck %s
+
+module {
+  gpu.module @ocl_program {
+    // CHECK: func.func private @_Z13get_global_idj(%arg0: i32, %arg1: vector<3xi32>, %arg2: vector<3xi32>, %arg3: vector<3xi32>, %arg4: vector<3xi32>) -> i64
+    func.func private @_Z13get_global_idj(%arg0: i32) -> i64 {
+      %c0 = arith.constant 0 : index
+      %c2_i32 = arith.constant 2 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %0 = arith.cmpi eq, %arg0, %c0_i32 : i32
+      cf.cond_br %0, ^bb3, ^bb1
+    ^bb1:  // pred: ^bb0
+      %1 = arith.cmpi eq, %arg0, %c1_i32 : i32
+      cf.cond_br %1, ^bb4, ^bb2
+    ^bb2:  // pred: ^bb1
+      %2 = arith.cmpi eq, %arg0, %c2_i32 : i32
+      cf.cond_br %2, ^bb5, ^bb6(%c0 : index)
+    ^bb3:  // pred: ^bb0
+      %3 = gpu.global_id  x
+      cf.br ^bb6(%3 : index)
+    ^bb4:  // pred: ^bb1
+      %4 = gpu.global_id  y
+      cf.br ^bb6(%4 : index)
+    ^bb5:  // pred: ^bb2
+      %5 = gpu.global_id  z
+      cf.br ^bb6(%5 : index)
+    ^bb6(%6: index):  // 4 preds: ^bb2, ^bb3, ^bb4, ^bb5
+      %7 = arith.index_cast %6 : index to i64
+      return %7 : i64
+    }
+    // CHECK: gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: !rawmem.ptr<i32, 1>, %arg4: vector<3xi32>, %arg5: vector<3xi32>, %arg6: vector<3xi32>, %arg7: vector<3xi32>) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}}
+    gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: i32) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}} {
+      %c0_i32 = arith.constant 0 : i32
+      // CHECK: func.call @_Z13get_global_idj(%c0_i32, %arg4, %arg5, %arg6, %arg7) : (i32, vector<3xi32>, vector<3xi32>, vector<3xi32>, vector<3xi32>) -> i64
+      %0 = func.call @_Z13get_global_idj(%c0_i32) : (i32) -> i64
+      %1 = arith.trunci %0 : i64 to i32
+      %2 = arith.cmpi ult, %1, %arg3 : i32
+      cf.cond_br %2, ^bb1, ^bb2
+    ^bb1:  // pred: ^bb0
+      %3 = arith.index_cast %1 : i32 to index
+      %4 = rawmem.load %arg0[%3] : !rawmem.ptr<f32, 1>, f32
+      %5 = arith.index_cast %1 : i32 to index
+      %6 = rawmem.load %arg1[%5] : !rawmem.ptr<f32, 1>, f32
+      %7 = arith.addf %4, %6 : f32
+      %8 = arith.index_cast %1 : i32 to index
+      rawmem.store %7, %arg2[%8] : f32, !rawmem.ptr<f32, 1>
+      cf.br ^bb2
+    ^bb2:  // 2 preds: ^bb0, ^bb1
+      gpu.return
+    }
+  }
+}

--- a/test/transforms/metal/air_abi.mlir
+++ b/test/transforms/metal/air_abi.mlir
@@ -29,7 +29,7 @@ module {
       %7 = arith.index_cast %6 : index to i64
       return %7 : i64
     }
-    // CHECK: gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: !rawmem.ptr<i32, 1>, %arg4: vector<3xi32>, %arg5: vector<3xi32>, %arg6: vector<3xi32>, %arg7: vector<3xi32>) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}}
+    // CHECK: gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: !rawmem.ptr<i32, 1>, %arg4: vector<3xi32> {emitc.thread_position_in_grid}, %arg5: vector<3xi32> {emitc.thread_position_in_threadgroup}, %arg6: vector<3xi32> {emitc.threads_per_threadgroup}, %arg7: vector<3xi32> {emitc.threadgroups_per_grid}) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}}
     gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: i32) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}} {
       %c0_i32 = arith.constant 0 : i32
       // CHECK: func.call @_Z13get_global_idj(%c0_i32, %arg4, %arg5, %arg6, %arg7) : (i32, vector<3xi32>, vector<3xi32>, vector<3xi32>, vector<3xi32>) -> i64

--- a/test/transforms/metal/air_gpu_ops.mlir
+++ b/test/transforms/metal/air_gpu_ops.mlir
@@ -1,0 +1,54 @@
+// RUN: lcl-opt --expand-gpu-builtins %s | FileCheck %s
+
+module {
+  gpu.module @ocl_program {
+    func.func private @_Z13get_global_idj(%arg0: i32, %arg1: vector<3xi32>, %arg2: vector<3xi32>, %arg3: vector<3xi32>, %arg4: vector<3xi32>) -> i64 {
+      %c0 = arith.constant 0 : index
+      %c2_i32 = arith.constant 2 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %0 = arith.cmpi eq, %arg0, %c0_i32 : i32
+      cf.cond_br %0, ^bb3, ^bb1
+    ^bb1:  // pred: ^bb0
+      %1 = arith.cmpi eq, %arg0, %c1_i32 : i32
+      cf.cond_br %1, ^bb4, ^bb2
+    ^bb2:  // pred: ^bb1
+      %2 = arith.cmpi eq, %arg0, %c2_i32 : i32
+      cf.cond_br %2, ^bb5, ^bb6(%c0 : index)
+    ^bb3:  // pred: ^bb0
+      // CHECK: [[VAL1:%[0-9]+]] = vector.extractelement %arg1[%c0_0 : index] : vector<3xi32>
+      %3 = gpu.global_id  x
+      cf.br ^bb6(%3 : index)
+    ^bb4:  // pred: ^bb1
+      // CHECK: [[VAL2:%[0-9]+]] = vector.extractelement %arg1[%c1 : index] : vector<3xi32>
+      %4 = gpu.global_id  y
+      cf.br ^bb6(%4 : index)
+    ^bb5:  // pred: ^bb2
+      // CHECK: [[VAL3:%[0-9]+]] = vector.extractelement %arg1[%c2 : index] : vector<3xi32>
+      %5 = gpu.global_id  z
+      cf.br ^bb6(%5 : index)
+    ^bb6(%6: index):  // 4 preds: ^bb2, ^bb3, ^bb4, ^bb5
+      %7 = arith.index_cast %6 : index to i64
+      return %7 : i64
+    }
+    gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: !rawmem.ptr<i32, 1>, %arg4: vector<3xi32>, %arg5: vector<3xi32>, %arg6: vector<3xi32>, %arg7: vector<3xi32>) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}} {
+      %0 = rawmem.load %arg3 : !rawmem.ptr<i32, 1>, i32
+      %c0_i32 = arith.constant 0 : i32
+      %1 = func.call @_Z13get_global_idj(%c0_i32, %arg4, %arg5, %arg6, %arg7) : (i32, vector<3xi32>, vector<3xi32>, vector<3xi32>, vector<3xi32>) -> i64
+      %2 = arith.trunci %1 : i64 to i32
+      %3 = arith.cmpi ult, %2, %0 : i32
+      cf.cond_br %3, ^bb1, ^bb2
+    ^bb1:  // pred: ^bb0
+      %4 = arith.index_cast %2 : i32 to index
+      %5 = rawmem.load %arg0[%4] : !rawmem.ptr<f32, 1>, f32
+      %6 = arith.index_cast %2 : i32 to index
+      %7 = rawmem.load %arg1[%6] : !rawmem.ptr<f32, 1>, f32
+      %8 = arith.addf %5, %7 : f32
+      %9 = arith.index_cast %2 : i32 to index
+      rawmem.store %8, %arg2[%9] : f32, !rawmem.ptr<f32, 1>
+      cf.br ^bb2
+    ^bb2:  // 2 preds: ^bb0, ^bb1
+      gpu.return
+    }
+  }
+}

--- a/test/transforms/metal/air_gpu_to_cpp.mlir
+++ b/test/transforms/metal/air_gpu_to_cpp.mlir
@@ -1,0 +1,54 @@
+// RUN: lcl-opt --convert-gpu-to-cpp %s | FileCheck %s
+module {
+  // CHECK: emitc.include <"metal_stdlib">
+  // CHECK: emitc.include <"simd/simd.h">
+  // CHECK-NOT: gpu.module
+  gpu.module @ocl_program {
+    func.func private @_Z13get_global_idj(%arg0: i32, %arg1: vector<3xi32>, %arg2: vector<3xi32>, %arg3: vector<3xi32>, %arg4: vector<3xi32>) -> i64 {
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %c2_i32 = arith.constant 2 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %0 = arith.cmpi eq, %arg0, %c0_i32 : i32
+      cf.cond_br %0, ^bb3(%c0 : index), ^bb1
+    ^bb1:  // pred: ^bb0
+      %1 = arith.cmpi eq, %arg0, %c1_i32 : i32
+      cf.cond_br %1, ^bb3(%c1 : index), ^bb2
+    ^bb2:  // pred: ^bb1
+      %2 = arith.cmpi eq, %arg0, %c2_i32 : i32
+      cf.cond_br %2, ^bb3(%c2 : index), ^bb4(%c0 : index)
+    ^bb3(%3: index):  // 3 preds: ^bb0, ^bb1, ^bb2
+      %4 = vector.extractelement %arg1[%3 : index] : vector<3xi32>
+      %5 = arith.index_cast %4 : i32 to index
+      cf.br ^bb4(%5 : index)
+    ^bb4(%6: index):  // 2 preds: ^bb2, ^bb3
+      %7 = arith.index_cast %6 : index to i64
+      return %7 : i64
+    }
+    // CHECK-NOT: gpu.func
+    // CHECK: func @vectorAdd
+    gpu.func @vectorAdd(%arg0: !rawmem.ptr<f32, 1>, %arg1: !rawmem.ptr<f32, 1>, %arg2: !rawmem.ptr<f32, 1>, %arg3: !rawmem.ptr<i32, 1>, %arg4: vector<3xi32>, %arg5: vector<3xi32>, %arg6: vector<3xi32>, %arg7: vector<3xi32>) kernel attributes {spv.entry_point_abi = {local_size = dense<1> : vector<3xi32>}} {
+      %c0_i32 = arith.constant 0 : i32
+      %0 = rawmem.load %arg3 : !rawmem.ptr<i32, 1>, i32
+      %1 = func.call @_Z13get_global_idj(%c0_i32, %arg4, %arg5, %arg6, %arg7) : (i32, vector<3xi32>, vector<3xi32>, vector<3xi32>, vector<3xi32>) -> i64
+      %2 = arith.trunci %1 : i64 to i32
+      %3 = arith.cmpi ult, %2, %0 : i32
+      cf.cond_br %3, ^bb1, ^bb2
+    ^bb1:  // pred: ^bb0
+      %4 = arith.index_cast %2 : i32 to index
+      %5 = rawmem.load %arg0[%4] : !rawmem.ptr<f32, 1>, f32
+      %6 = arith.index_cast %2 : i32 to index
+      %7 = rawmem.load %arg1[%6] : !rawmem.ptr<f32, 1>, f32
+      %8 = arith.addf %5, %7 : f32
+      %9 = arith.index_cast %2 : i32 to index
+      rawmem.store %8, %arg2[%9] : f32, !rawmem.ptr<f32, 1>
+      cf.br ^bb2
+    ^bb2:  // 2 preds: ^bb0, ^bb1
+      // CHECK-NOT: gpu.return
+      // CHECK: return
+      gpu.return
+    }
+  }
+}

--- a/tools/lcl-opt/CMakeLists.txt
+++ b/tools/lcl-opt/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(lcl-opt PRIVATE
   ${conversion_libs}
   MLIROptLib
   MLIRRawMemory
+  LCLPasses
   )
 
 target_include_directories(lcl-opt PRIVATE

--- a/tools/lcl-opt/main.cpp
+++ b/tools/lcl-opt/main.cpp
@@ -31,6 +31,9 @@ int main(int argc, char **argv) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return lcl::createExpandGPUBuiltinsPass();
   });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return lcl::createGPUToCppPass();
+  });
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::rawmem::RawMemoryDialect>();

--- a/tools/lcl-opt/main.cpp
+++ b/tools/lcl-opt/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char **argv) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return lcl::createAIRKernelABIPass();
   });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return lcl::createExpandGPUBuiltinsPass();
+  });
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::rawmem::RawMemoryDialect>();

--- a/tools/lcl-opt/main.cpp
+++ b/tools/lcl-opt/main.cpp
@@ -20,10 +20,14 @@
 #include "llvm/Support/ToolOutputFile.h"
 
 #include "RawMemory/RawMemoryDialect.h"
+#include "passes/mlir/passes.hpp"
 
 int main(int argc, char **argv) {
   mlir::registerAllPasses();
   // TODO: Register LibreCL passes here.
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return lcl::createAIRKernelABIPass();
+  });
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::rawmem::RawMemoryDialect>();


### PR DESCRIPTION
Introduce a basic compiler flow from LLVM IR to Metal Shading Language source code. This is done by leveraging MLIR's EmitC infrastructure with a bit of a hand-written MLIT to C++ conversion.

The major issue right now is use of unstructured control flow and `goto` statement, which is unsupported by MSL. This should be partially addressed by #10.

Example MSL result:
```cpp
#include <metal_stdlib>
#include <simd/simd.h>
int64_t _Z13get_global_idj(int32_t v1, vec<int32_t, 3> v2, vec<int32_t, 3> v3, vec<int32_t, 3> v4, vec<int32_t, 3> v5) {
  size_t v6;
  size_t v7;
  size_t v8;
  int32_t v9;
  int32_t v10;
  int32_t v11;
  bool v12;
  bool v13;
  bool v14;
  int32_t v15;
  size_t v16;
  int64_t v17;
  size_t v18;
  size_t v19;
  v6 = 2;
  v7 = 1;
  v8 = 0;
  v9 = 2;
  v10 = 1;
  v11 = 0;
  v12 = v1 == v11;
  if (v12) {
    v18 = v8;
    goto label4;
  } else {
    goto label2;
  }
label2:
  v13 = v1 == v10;
  if (v13) {
    v18 = v7;
    goto label4;
  } else {
    goto label3;
  }
label3:
  v14 = v1 == v9;
  if (v14) {
    v18 = v6;
    goto label4;
  } else {
    v19 = v8;
    goto label5;
  }
label4:
  v15 = v2[v18];
  v16 = (size_t) v15;
  v19 = v16;
  goto label5;
label5:
  v17 = (int64_t) v19;
  return v17;
}

kernel void vectorAdd(device float* v1, device float* v2, device float* v3, device int32_t* v4, vec<int32_t, 3> v5 [[thread_position_in_grid]], vec<int32_t, 3> v6 [[thread_position_in_threadgroup]], vec<int32_t, 3> v7 [[threads_per_threadgroup]], vec<int32_t, 3> v8 [[threadgroups_per_grid]]) {
  int32_t v9;
  int32_t v10;
  int64_t v11;
  int32_t v12;
  bool v13;
  size_t v14;
  float v15;
  size_t v16;
  float v17;
  float v18;
  size_t v19;
  v9 = 0;
  v10 = v4[0;
  v11 = _Z13get_global_idj(v9, v5, v6, v7, v8);
  v12 = (int32_t) v11;
  v13 = v12 <= v10;
  if (v13) {
    goto label2;
  } else {
    goto label3;
  }
label2:
  v14 = (size_t) v12;
  v15 = v1[v14];
  v16 = (size_t) v12;
  v17 = v2[v16];
  v18 = v15 + v17;
  v19 = (size_t) v12;
  v3[v19] = v18;
  goto label3;
label3:
  return;
}
```