### PR TITLE
chore: improve build system configuration

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -42,10 +42,9 @@ jobs:
         key: ${{ runner.os }}-build-${{ github.sha }}
         restore-keys: ${{ runner.os }}-build-
     - name: Build
-      with:
-        env:
-          RUSTC_WRAPPER: sccache
-          SCCACHE_DIR: ${{ github.workspace }}/cache
+      env:
+        RUSTC_WRAPPER: sccache
+        SCCACHE_DIR: ${{ github.workspace }}/cache
       run: cargo build --workspace -vv
     - name: Runtime smoke test
       run: cargo nextest run --all

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Ubuntu dependencies
       if: runner.os == 'Linux'
       run: |
-        sudo apt install -yqq ccache ninja-build libtbb-dev spirv-tools libvulkan-dev
+        sudo apt install -yqq ninja-build libtbb-dev spirv-tools libvulkan-dev
         curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 15
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-11 15
@@ -27,17 +27,16 @@ jobs:
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        brew install ccache ninja tbb ncurses
+        brew install ninja tbb ncurses
         curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache build artifacts
-      uses: actions/cache@v3
+    - name: Configure sccache
+      uses: visvirial/sccache-action@v1
       with:
-        path: target
-        key: ${{ runner.os }}-build-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-build-
+        cache-key: ${{ runner.os }}-build-${{ github.sha }}
+        release-name: latest
     - name: Build
       run: cargo build --workspace -vv
     - name: Runtime smoke test

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -24,20 +24,28 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 15
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-11 15
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 15
+        wget -P /tmp/ https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
+        tar -xvf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -C /tmp/
+        sudo install /tmp/sccache /usr/bin/sccache
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        brew install ninja tbb ncurses
+        brew install sccache ninja tbb ncurses
         curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Configure sccache
-      uses: visvirial/sccache-action@v1
+    - name: Cache build artifacts
+      uses: actions/cache@v3
       with:
-        cache-key: ${{ runner.os }}-build-${{ github.sha }}
-        release-name: latest
+        path: ${{ github.workspace }}/cache
+        key: ${{ runner.os }}-build-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-build-
     - name: Build
+      with:
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_DIR: ${{ github.workspace }}/cache
       run: cargo build --workspace -vv
     - name: Runtime smoke test
       run: cargo nextest run --all

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -26,7 +26,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 15
         wget -P /tmp/ https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
         tar -xvf /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -C /tmp/
-        sudo install /tmp/sccache /usr/bin/sccache
+        sudo install /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -25,7 +25,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-11 15
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 15
         wget -P /tmp/ https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-        tar -xvf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -C /tmp/
+        tar -xvf /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -C /tmp/
         sudo install /tmp/sccache /usr/bin/sccache
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -2,70 +2,11 @@
 
 BASE=$(dirname -- "$(readlink -f "${BASH_SOURCE}")")
 
-Help() {
-  echo "Available options:"
-  echo " h - show this guide"
-  echo " d - enable debug builds"
-  echo " l - use LLD linker"
-  echo
-  exit 0
-}
+cd $BASE/third_party/llvm-project/
 
-if [[ "$CI" = 'true' ]]; then
-  echo "enabling ccache for GitHub Actions"
-  CACHE_LOC="-DLLVM_CCACHE_DIR=\"$GITHUB_WORKSPACE/cache\" -DLLVM_CCACHE_BUILD=ON -DLLVM_CCACHE_MAXSIZE=\"5G\""
-  BUILD_TYPE=Release
-  ASSERTIONS=OFF
-  USE_LLD=OFF
-else
-  BUILD_TYPE=Release
-  ASSERTIONS=ON
-  USE_LLD=OFF
-  while getopts ":hdl" options; do
-    case "${options}" in
-      h)
-        Help
-        ;;
-      d)
-        BUILD_TYPE=Debug
-        ;;
-      l)
-        USE_LLD=ON
-        ;;
-      \?)
-        Help
-    esac
-  done
-fi
-
-set -e
-
-cd $BASE
-
-if [[ ! -d $BASE/third_party/llvm-project/build ]]; then
-  cd third_party/llvm-project
-
-  mkdir -p build
+if [[ ! -d `git status --porcelain` ]]; then
 
   git apply ../llvm_patches/0001-mlir-spirv-Handle-nested-global-variable-references-.patch
 
-  cd build
-
-  # TODO use sccache
-  cmake -GNinja \
-    -DLLVM_EXTERNAL_PROJECTS="llvm-spirv" \
-    -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR="$PWD/../../SPIRV-LLVM-Translator" \
-    -DLLVM_ENABLE_PROJECTS="mlir;clang;lld" \
-    -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" \
-    -DLLVM_ENABLE_ASSERTIONS=$ASSERTIONS \
-    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLLVM_ENABLE_LLD=$USE_LLD \
-    $CACHE_LOC \
-    ../llvm/
 fi
-
-cd $BASE/third_party/llvm-project/build
-
-ninja
 

--- a/src/compiler/build.rs
+++ b/src/compiler/build.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 use which::which;
+use std::fs;
 
 // Borrowed from Rust repo
 // https://github.com/rust-lang/rust/blob/master/compiler/rustc_llvm/build.rs
@@ -24,6 +25,9 @@ fn rerun_if_changed_anything_in_dir(dir: &Path) {
 }
 
 fn main() {
+    let wrapper = env::var("RUSTC_WRAPPER").unwrap_or("none".to_string());
+    let out_dir = env::var("OUT_DIR").unwrap_or("none".to_string());
+
     let dir = String::from(env::current_dir().unwrap().as_os_str().to_str().unwrap());
 
     Command::new("bash")
@@ -31,45 +35,86 @@ fn main() {
         .status()
         .unwrap();
 
+    #[cfg(not(target_os = "macos"))]
+    let use_mold = which("mold").is_ok();
+    #[cfg(target_os = "macos")]
+    let use_mold = false;
+
+    let use_lld = which("lld").is_ok();
+
+    let use_ninja = which("ninja").is_ok();
+
+    let llvm_out = format!("{}/../../../llvm_build", out_dir);
+    fs::create_dir_all(llvm_out.as_str());
+
+    let mut llvm_cfg = Box::new(Config::new("../../third_party/llvm-project/llvm/"));
+
+    llvm_cfg.define("LLVM_EXTERNAL_PROJECTS", "llvm-spirv")
+        .define("LLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR", std::format!("{}/../../third_party/SPIRV-LLVM-Translator", dir))
+        .define("LLVM_ENABLE_PROJECTS", "mlir;clang;lld")
+        .define("LLVM_TARGETS_TO_BUILD", "host;AMDGPU;NVPTX")
+        .define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")
+        .profile("Release")
+        .out_dir(llvm_out.as_str());
+
+    if wrapper.contains("sccache") {
+        llvm_cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", wrapper.as_str())
+            .define("CMAKE_C_COMPILER_LAUNCHER", wrapper.as_str());
+    }
+
+    if use_mold {
+        llvm_cfg.define("LLVM_USE_LINKER", "mold");
+    } else if use_lld {
+        llvm_cfg.define("LLVM_USE_LINKER", "lld");
+    }
+
+    if use_ninja {
+        llvm_cfg.generator("Ninja");
+    }
+
+    llvm_cfg.build();
+
+    let compiler_out = format!("{}/../../../lcl_compiler", out_dir);
+    fs::create_dir_all(compiler_out.as_str());
+
     let mut cfg = Box::new(Config::new("../../"));
+    if wrapper.contains("sccache") {
+        cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", wrapper.as_str())
+            .define("CMAKE_C_COMPILER_LAUNCHER", wrapper.as_str());
+    }
     cfg.define(
         "MLIR_DIR",
         std::format!(
-            "{}{}",
-            dir,
-            "/../../third_party/llvm-project/build/lib/cmake/mlir"
+            "{}/lib/cmake/mlir",
+            llvm_out.as_str()
         ),
     )
     .define(
         "LLVM_DIR",
         std::format!(
-            "{}{}",
-            dir,
-            "/../../third_party/llvm-project/build/lib/cmake/llvm"
+            "{}/lib/cmake/llvm",
+            llvm_out.as_str()
         ),
     )
     .define(
         "Clang_DIR",
         std::format!(
-            "{}{}",
-            dir,
-            "/../../third_party/llvm-project/build/lib/cmake/clang"
+            "{}/lib/cmake/clang",
+            llvm_out.as_str()
         ),
     )
-    .define("LLVM_ENABLE_ASSERTIONS", "OFF");
-    let mold = which("mold");
-    #[cfg(not(target_os = "macos"))]
-    let use_mold = mold.is_ok();
-    #[cfg(target_os = "macos")]
-    let use_mold = false;
+    .define("LLVM_ENABLE_ASSERTIONS", "OFF")
+    .out_dir(compiler_out.as_str());
+
     if use_mold {
         cfg.define("LIBRECL_LINKER", "mold");
         println!("cargo:rustc-link-arg=-fuse-ld=mold");
-    } else if which("lld").is_ok() {
+    } else if use_lld {
         cfg.define("LIBRECL_LINKER", "lld");
+        println!("cargo:rustc-link-arg=-fuse-ld=lld");
     }
 
-    if which("ninja").is_ok() {
+    if use_ninja {
         cfg.generator("Ninja");
     }
 
@@ -81,4 +126,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}/lib64", dst.display());
     rerun_if_changed_anything_in_dir(Path::new("../../third_party/llvm-project"));
     rerun_if_changed_anything_in_dir(Path::new("../compiler"));
+    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../build_dependencies.sh");
 }


### PR DESCRIPTION
Build LLVM as part of Cargo build, enable sccache to speed up builds of both Rust and C++ code.