### PR TITLE
refactor(rt): improve overall error handling

### DIFF
--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = "1.0.0"
 tokio = { version = "1.20.0", features = ["rt-multi-thread"] }
 bytemuck = "1.11.0"
 ocl_type_wrapper = { path = "../../utils/ocl_type_wrapper" }
+tracing = "0.1.36"
 pytorch-cpuinfo = "0.1.1"
 
 [lib]

--- a/src/runtime/api/cl_error_codes.rs
+++ b/src/runtime/api/cl_error_codes.rs
@@ -1,0 +1,343 @@
+#[derive(Debug, Clone)]
+pub enum ClError {
+    Success(ErrorDescription),
+    DeviceNotFound(ErrorDescription),
+    DeviceNotAvailable(ErrorDescription),
+    CompilerNotAvailable(ErrorDescription),
+    MemObjectAllocationFailure(ErrorDescription),
+    OutOfResources(ErrorDescription),
+    OutOfHostMemory(ErrorDescription),
+    ProfilingInfoNotAvailable(ErrorDescription),
+    MemCopyOverlap(ErrorDescription),
+    ImageFormatMismatch(ErrorDescription),
+    ImageFormatNotSupported(ErrorDescription),
+    BuildProgramFailure(ErrorDescription),
+    MapFailure(ErrorDescription),
+    MisalignedSubBufferOffset(ErrorDescription),
+    ExecStatusErrorForEventsInWaitList(ErrorDescription),
+    CompileProgramFailure(ErrorDescription),
+    LinkerNotAvailable(ErrorDescription),
+    LinkProgramFailure(ErrorDescription),
+    DevicePartitionFailed(ErrorDescription),
+    KernelArgInfoNotAvailable(ErrorDescription),
+    InvalidValue(ErrorDescription),
+    InvalidDeviceType(ErrorDescription),
+    InvalidPlatform(ErrorDescription),
+    InvalidDevice(ErrorDescription),
+    InvalidContext(ErrorDescription),
+    InvalidQueueProperties(ErrorDescription),
+    InvalidCommandQueue(ErrorDescription),
+    InvalidHostPtr(ErrorDescription),
+    InvalidMemObject(ErrorDescription),
+    InvalidImageFormatDescriptor(ErrorDescription),
+    InvalidImageSize(ErrorDescription),
+    InvalidSampler(ErrorDescription),
+    InvalidBinary(ErrorDescription),
+    InvalidBuildOptions(ErrorDescription),
+    InvalidProgram(ErrorDescription),
+    InvalidProgramExecutable(ErrorDescription),
+    InvalidKernelName(ErrorDescription),
+    InvalidKernelDefinition(ErrorDescription),
+    InvalidKernel(ErrorDescription),
+    InvalidArgIndex(ErrorDescription),
+    InvalidArgValue(ErrorDescription),
+    InvalidArgSize(ErrorDescription),
+    InvalidKernelArgs(ErrorDescription),
+    InvalidWorkDimension(ErrorDescription),
+    InvalidWorkGroupSize(ErrorDescription),
+    InvalidWorkItemSize(ErrorDescription),
+    InvalidGlobalOffset(ErrorDescription),
+    InvalidEventWaitList(ErrorDescription),
+    InvalidEvent(ErrorDescription),
+    InvalidOperation(ErrorDescription),
+    InvalidGlObject(ErrorDescription),
+    InvalidBufferSize(ErrorDescription),
+    InvalidMipLevel(ErrorDescription),
+    InvalidGlobalWorkSize(ErrorDescription),
+    InvalidProperty(ErrorDescription),
+    InvalidImageDescriptor(ErrorDescription),
+    InvalidCompilerOptions(ErrorDescription),
+    InvalidLinkerOptions(ErrorDescription),
+    InvalidDevicePartitionCount(ErrorDescription),
+    InvalidPipeSize(ErrorDescription),
+    InvalidDeviceQueue(ErrorDescription),
+    InvalidSpecId(ErrorDescription),
+    MaxSizeRestrictionExceeded(ErrorDescription),
+}
+
+impl ClError {
+    pub fn error_code(&self) -> cl_int {
+        match self {
+            ClError::Success(_) => 0 as cl_int,
+            ClError::DeviceNotFound(_) => -1 as cl_int,
+            ClError::DeviceNotAvailable(_) => -2 as cl_int,
+            ClError::CompilerNotAvailable(_) => -3 as cl_int,
+            ClError::MemObjectAllocationFailure(_) => -4 as cl_int,
+            ClError::OutOfResources(_) => -5 as cl_int,
+            ClError::OutOfHostMemory(_) => -6 as cl_int,
+            ClError::ProfilingInfoNotAvailable(_) => -7 as cl_int,
+            ClError::MemCopyOverlap(_) => -8 as cl_int,
+            ClError::ImageFormatMismatch(_) => -9 as cl_int,
+            ClError::ImageFormatNotSupported(_) => -10 as cl_int,
+            ClError::BuildProgramFailure(_) => -11 as cl_int,
+            ClError::MapFailure(_) => -12 as cl_int,
+            ClError::MisalignedSubBufferOffset(_) => -13 as cl_int,
+            ClError::ExecStatusErrorForEventsInWaitList(_) => -14 as cl_int,
+            ClError::CompileProgramFailure(_) => -15 as cl_int,
+            ClError::LinkerNotAvailable(_) => -16 as cl_int,
+            ClError::LinkProgramFailure(_) => -17 as cl_int,
+            ClError::DevicePartitionFailed(_) => -18 as cl_int,
+            ClError::KernelArgInfoNotAvailable(_) => -19 as cl_int,
+            ClError::InvalidValue(_) => -30 as cl_int,
+            ClError::InvalidDeviceType(_) => -31 as cl_int,
+            ClError::InvalidPlatform(_) => -32 as cl_int,
+            ClError::InvalidDevice(_) => -33 as cl_int,
+            ClError::InvalidContext(_) => -34 as cl_int,
+            ClError::InvalidQueueProperties(_) => -35 as cl_int,
+            ClError::InvalidCommandQueue(_) => -36 as cl_int,
+            ClError::InvalidHostPtr(_) => -37 as cl_int,
+            ClError::InvalidMemObject(_) => -38 as cl_int,
+            ClError::InvalidImageFormatDescriptor(_) => -39 as cl_int,
+            ClError::InvalidImageSize(_) => -40 as cl_int,
+            ClError::InvalidSampler(_) => -41 as cl_int,
+            ClError::InvalidBinary(_) => -42 as cl_int,
+            ClError::InvalidBuildOptions(_) => -43 as cl_int,
+            ClError::InvalidProgram(_) => -44 as cl_int,
+            ClError::InvalidProgramExecutable(_) => -45 as cl_int,
+            ClError::InvalidKernelName(_) => -46 as cl_int,
+            ClError::InvalidKernelDefinition(_) => -47 as cl_int,
+            ClError::InvalidKernel(_) => -48 as cl_int,
+            ClError::InvalidArgIndex(_) => -49 as cl_int,
+            ClError::InvalidArgValue(_) => -50 as cl_int,
+            ClError::InvalidArgSize(_) => -51 as cl_int,
+            ClError::InvalidKernelArgs(_) => -52 as cl_int,
+            ClError::InvalidWorkDimension(_) => -53 as cl_int,
+            ClError::InvalidWorkGroupSize(_) => -54 as cl_int,
+            ClError::InvalidWorkItemSize(_) => -55 as cl_int,
+            ClError::InvalidGlobalOffset(_) => -56 as cl_int,
+            ClError::InvalidEventWaitList(_) => -57 as cl_int,
+            ClError::InvalidEvent(_) => -58 as cl_int,
+            ClError::InvalidOperation(_) => -59 as cl_int,
+            ClError::InvalidGlObject(_) => -60 as cl_int,
+            ClError::InvalidBufferSize(_) => -61 as cl_int,
+            ClError::InvalidMipLevel(_) => -62 as cl_int,
+            ClError::InvalidGlobalWorkSize(_) => -63 as cl_int,
+            ClError::InvalidProperty(_) => -64 as cl_int,
+            ClError::InvalidImageDescriptor(_) => -65 as cl_int,
+            ClError::InvalidCompilerOptions(_) => -66 as cl_int,
+            ClError::InvalidLinkerOptions(_) => -67 as cl_int,
+            ClError::InvalidDevicePartitionCount(_) => -68 as cl_int,
+            ClError::InvalidPipeSize(_) => -69 as cl_int,
+            ClError::InvalidDeviceQueue(_) => -70 as cl_int,
+            ClError::InvalidSpecId(_) => -71 as cl_int,
+            ClError::MaxSizeRestrictionExceeded(_) => -72 as cl_int,
+        }
+    }
+
+
+    pub fn get_name(&self) -> &str {
+        match self {
+            ClError::Success(_) => "CL_SUCCESS",
+            ClError::DeviceNotFound(_) => "CL_DEVICE_NOT_FOUND",
+            ClError::DeviceNotAvailable(_) => "CL_DEVICE_NOT_AVAILABLE",
+            ClError::CompilerNotAvailable(_) => "CL_COMPILER_NOT_AVAILABLE",
+            ClError::MemObjectAllocationFailure(_) => "CL_MEM_OBJECT_ALLOCATION_FAILURE",
+            ClError::OutOfResources(_) => "CL_OUT_OF_RESOURCES",
+            ClError::OutOfHostMemory(_) => "CL_OUT_OF_HOST_MEMORY",
+            ClError::ProfilingInfoNotAvailable(_) => "CL_PROFILING_INFO_NOT_AVAILABLE",
+            ClError::MemCopyOverlap(_) => "CL_MEM_COPY_OVERLAP",
+            ClError::ImageFormatMismatch(_) => "CL_IMAGE_FORMAT_MISMATCH",
+            ClError::ImageFormatNotSupported(_) => "CL_IMAGE_FORMAT_NOT_SUPPORTED",
+            ClError::BuildProgramFailure(_) => "CL_BUILD_PROGRAM_FAILURE",
+            ClError::MapFailure(_) => "CL_MAP_FAILURE",
+            ClError::MisalignedSubBufferOffset(_) => "CL_MISALIGNED_SUB_BUFFER_OFFSET",
+            ClError::ExecStatusErrorForEventsInWaitList(_) => "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST",
+            ClError::CompileProgramFailure(_) => "CL_COMPILE_PROGRAM_FAILURE",
+            ClError::LinkerNotAvailable(_) => "CL_LINKER_NOT_AVAILABLE",
+            ClError::LinkProgramFailure(_) => "CL_LINK_PROGRAM_FAILURE",
+            ClError::DevicePartitionFailed(_) => "CL_DEVICE_PARTITION_FAILED",
+            ClError::KernelArgInfoNotAvailable(_) => "CL_KERNEL_ARG_INFO_NOT_AVAILABLE",
+            ClError::InvalidValue(_) => "CL_INVALID_VALUE",
+            ClError::InvalidDeviceType(_) => "CL_INVALID_DEVICE_TYPE",
+            ClError::InvalidPlatform(_) => "CL_INVALID_PLATFORM",
+            ClError::InvalidDevice(_) => "CL_INVALID_DEVICE",
+            ClError::InvalidContext(_) => "CL_INVALID_CONTEXT",
+            ClError::InvalidQueueProperties(_) => "CL_INVALID_QUEUE_PROPERTIES",
+            ClError::InvalidCommandQueue(_) => "CL_INVALID_COMMAND_QUEUE",
+            ClError::InvalidHostPtr(_) => "CL_INVALID_HOST_PTR",
+            ClError::InvalidMemObject(_) => "CL_INVALID_MEM_OBJECT",
+            ClError::InvalidImageFormatDescriptor(_) => "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR",
+            ClError::InvalidImageSize(_) => "CL_INVALID_IMAGE_SIZE",
+            ClError::InvalidSampler(_) => "CL_INVALID_SAMPLER",
+            ClError::InvalidBinary(_) => "CL_INVALID_BINARY",
+            ClError::InvalidBuildOptions(_) => "CL_INVALID_BUILD_OPTIONS",
+            ClError::InvalidProgram(_) => "CL_INVALID_PROGRAM",
+            ClError::InvalidProgramExecutable(_) => "CL_INVALID_PROGRAM_EXECUTABLE",
+            ClError::InvalidKernelName(_) => "CL_INVALID_KERNEL_NAME",
+            ClError::InvalidKernelDefinition(_) => "CL_INVALID_KERNEL_DEFINITION",
+            ClError::InvalidKernel(_) => "CL_INVALID_KERNEL",
+            ClError::InvalidArgIndex(_) => "CL_INVALID_ARG_INDEX",
+            ClError::InvalidArgValue(_) => "CL_INVALID_ARG_VALUE",
+            ClError::InvalidArgSize(_) => "CL_INVALID_ARG_SIZE",
+            ClError::InvalidKernelArgs(_) => "CL_INVALID_KERNEL_ARGS",
+            ClError::InvalidWorkDimension(_) => "CL_INVALID_WORK_DIMENSION",
+            ClError::InvalidWorkGroupSize(_) => "CL_INVALID_WORK_GROUP_SIZE",
+            ClError::InvalidWorkItemSize(_) => "CL_INVALID_WORK_ITEM_SIZE",
+            ClError::InvalidGlobalOffset(_) => "CL_INVALID_GLOBAL_OFFSET",
+            ClError::InvalidEventWaitList(_) => "CL_INVALID_EVENT_WAIT_LIST",
+            ClError::InvalidEvent(_) => "CL_INVALID_EVENT",
+            ClError::InvalidOperation(_) => "CL_INVALID_OPERATION",
+            ClError::InvalidGlObject(_) => "CL_INVALID_GL_OBJECT",
+            ClError::InvalidBufferSize(_) => "CL_INVALID_BUFFER_SIZE",
+            ClError::InvalidMipLevel(_) => "CL_INVALID_MIP_LEVEL",
+            ClError::InvalidGlobalWorkSize(_) => "CL_INVALID_GLOBAL_WORK_SIZE",
+            ClError::InvalidProperty(_) => "CL_INVALID_PROPERTY",
+            ClError::InvalidImageDescriptor(_) => "CL_INVALID_IMAGE_DESCRIPTOR",
+            ClError::InvalidCompilerOptions(_) => "CL_INVALID_COMPILER_OPTIONS",
+            ClError::InvalidLinkerOptions(_) => "CL_INVALID_LINKER_OPTIONS",
+            ClError::InvalidDevicePartitionCount(_) => "CL_INVALID_DEVICE_PARTITION_COUNT",
+            ClError::InvalidPipeSize(_) => "CL_INVALID_PIPE_SIZE",
+            ClError::InvalidDeviceQueue(_) => "CL_INVALID_DEVICE_QUEUE",
+            ClError::InvalidSpecId(_) => "CL_INVALID_SPEC_ID",
+            ClError::MaxSizeRestrictionExceeded(_) => "CL_MAX_SIZE_RESTRICTION_EXCEEDED",
+        }
+    }
+}
+
+impl fmt::Display for ClError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error_descr = match self {
+            ClError::Success(desc) => desc,
+            ClError::DeviceNotFound(desc) => desc,
+            ClError::DeviceNotAvailable(desc) => desc,
+            ClError::CompilerNotAvailable(desc) => desc,
+            ClError::MemObjectAllocationFailure(desc) => desc,
+            ClError::OutOfResources(desc) => desc,
+            ClError::OutOfHostMemory(desc) => desc,
+            ClError::ProfilingInfoNotAvailable(desc) => desc,
+            ClError::MemCopyOverlap(desc) => desc,
+            ClError::ImageFormatMismatch(desc) => desc,
+            ClError::ImageFormatNotSupported(desc) => desc,
+            ClError::BuildProgramFailure(desc) => desc,
+            ClError::MapFailure(desc) => desc,
+            ClError::MisalignedSubBufferOffset(desc) => desc,
+            ClError::ExecStatusErrorForEventsInWaitList(desc) => desc,
+            ClError::CompileProgramFailure(desc) => desc,
+            ClError::LinkerNotAvailable(desc) => desc,
+            ClError::LinkProgramFailure(desc) => desc,
+            ClError::DevicePartitionFailed(desc) => desc,
+            ClError::KernelArgInfoNotAvailable(desc) => desc,
+            ClError::InvalidValue(desc) => desc,
+            ClError::InvalidDeviceType(desc) => desc,
+            ClError::InvalidPlatform(desc) => desc,
+            ClError::InvalidDevice(desc) => desc,
+            ClError::InvalidContext(desc) => desc,
+            ClError::InvalidQueueProperties(desc) => desc,
+            ClError::InvalidCommandQueue(desc) => desc,
+            ClError::InvalidHostPtr(desc) => desc,
+            ClError::InvalidMemObject(desc) => desc,
+            ClError::InvalidImageFormatDescriptor(desc) => desc,
+            ClError::InvalidImageSize(desc) => desc,
+            ClError::InvalidSampler(desc) => desc,
+            ClError::InvalidBinary(desc) => desc,
+            ClError::InvalidBuildOptions(desc) => desc,
+            ClError::InvalidProgram(desc) => desc,
+            ClError::InvalidProgramExecutable(desc) => desc,
+            ClError::InvalidKernelName(desc) => desc,
+            ClError::InvalidKernelDefinition(desc) => desc,
+            ClError::InvalidKernel(desc) => desc,
+            ClError::InvalidArgIndex(desc) => desc,
+            ClError::InvalidArgValue(desc) => desc,
+            ClError::InvalidArgSize(desc) => desc,
+            ClError::InvalidKernelArgs(desc) => desc,
+            ClError::InvalidWorkDimension(desc) => desc,
+            ClError::InvalidWorkGroupSize(desc) => desc,
+            ClError::InvalidWorkItemSize(desc) => desc,
+            ClError::InvalidGlobalOffset(desc) => desc,
+            ClError::InvalidEventWaitList(desc) => desc,
+            ClError::InvalidEvent(desc) => desc,
+            ClError::InvalidOperation(desc) => desc,
+            ClError::InvalidGlObject(desc) => desc,
+            ClError::InvalidBufferSize(desc) => desc,
+            ClError::InvalidMipLevel(desc) => desc,
+            ClError::InvalidGlobalWorkSize(desc) => desc,
+            ClError::InvalidProperty(desc) => desc,
+            ClError::InvalidImageDescriptor(desc) => desc,
+            ClError::InvalidCompilerOptions(desc) => desc,
+            ClError::InvalidLinkerOptions(desc) => desc,
+            ClError::InvalidDevicePartitionCount(desc) => desc,
+            ClError::InvalidPipeSize(desc) => desc,
+            ClError::InvalidDeviceQueue(desc) => desc,
+            ClError::InvalidSpecId(desc) => desc,
+            ClError::MaxSizeRestrictionExceeded(desc) => desc,
+        };
+        write!(f, "{} ({}) - {} from:\n{:?}", self.error_code(), self.get_name(), error_descr.message, error_descr.backtrace)
+    }
+}
+#[cfg(test)]
+pub mod error_codes {
+    pub const CL_SUCCESS: cl_int = 0;
+    pub const CL_DEVICE_NOT_FOUND: cl_int = -1;
+    pub const CL_DEVICE_NOT_AVAILABLE: cl_int = -2;
+    pub const CL_COMPILER_NOT_AVAILABLE: cl_int = -3;
+    pub const CL_MEM_OBJECT_ALLOCATION_FAILURE: cl_int = -4;
+    pub const CL_OUT_OF_RESOURCES: cl_int = -5;
+    pub const CL_OUT_OF_HOST_MEMORY: cl_int = -6;
+    pub const CL_PROFILING_INFO_NOT_AVAILABLE: cl_int = -7;
+    pub const CL_MEM_COPY_OVERLAP: cl_int = -8;
+    pub const CL_IMAGE_FORMAT_MISMATCH: cl_int = -9;
+    pub const CL_IMAGE_FORMAT_NOT_SUPPORTED: cl_int = -10;
+    pub const CL_BUILD_PROGRAM_FAILURE: cl_int = -11;
+    pub const CL_MAP_FAILURE: cl_int = -12;
+    pub const CL_MISALIGNED_SUB_BUFFER_OFFSET: cl_int = -13;
+    pub const CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST: cl_int = -14;
+    pub const CL_COMPILE_PROGRAM_FAILURE: cl_int = -15;
+    pub const CL_LINKER_NOT_AVAILABLE: cl_int = -16;
+    pub const CL_LINK_PROGRAM_FAILURE: cl_int = -17;
+    pub const CL_DEVICE_PARTITION_FAILED: cl_int = -18;
+    pub const CL_KERNEL_ARG_INFO_NOT_AVAILABLE: cl_int = -19;
+    pub const CL_INVALID_VALUE: cl_int = -30;
+    pub const CL_INVALID_DEVICE_TYPE: cl_int = -31;
+    pub const CL_INVALID_PLATFORM: cl_int = -32;
+    pub const CL_INVALID_DEVICE: cl_int = -33;
+    pub const CL_INVALID_CONTEXT: cl_int = -34;
+    pub const CL_INVALID_QUEUE_PROPERTIES: cl_int = -35;
+    pub const CL_INVALID_COMMAND_QUEUE: cl_int = -36;
+    pub const CL_INVALID_HOST_PTR: cl_int = -37;
+    pub const CL_INVALID_MEM_OBJECT: cl_int = -38;
+    pub const CL_INVALID_IMAGE_FORMAT_DESCRIPTOR: cl_int = -39;
+    pub const CL_INVALID_IMAGE_SIZE: cl_int = -40;
+    pub const CL_INVALID_SAMPLER: cl_int = -41;
+    pub const CL_INVALID_BINARY: cl_int = -42;
+    pub const CL_INVALID_BUILD_OPTIONS: cl_int = -43;
+    pub const CL_INVALID_PROGRAM: cl_int = -44;
+    pub const CL_INVALID_PROGRAM_EXECUTABLE: cl_int = -45;
+    pub const CL_INVALID_KERNEL_NAME: cl_int = -46;
+    pub const CL_INVALID_KERNEL_DEFINITION: cl_int = -47;
+    pub const CL_INVALID_KERNEL: cl_int = -48;
+    pub const CL_INVALID_ARG_INDEX: cl_int = -49;
+    pub const CL_INVALID_ARG_VALUE: cl_int = -50;
+    pub const CL_INVALID_ARG_SIZE: cl_int = -51;
+    pub const CL_INVALID_KERNEL_ARGS: cl_int = -52;
+    pub const CL_INVALID_WORK_DIMENSION: cl_int = -53;
+    pub const CL_INVALID_WORK_GROUP_SIZE: cl_int = -54;
+    pub const CL_INVALID_WORK_ITEM_SIZE: cl_int = -55;
+    pub const CL_INVALID_GLOBAL_OFFSET: cl_int = -56;
+    pub const CL_INVALID_EVENT_WAIT_LIST: cl_int = -57;
+    pub const CL_INVALID_EVENT: cl_int = -58;
+    pub const CL_INVALID_OPERATION: cl_int = -59;
+    pub const CL_INVALID_GL_OBJECT: cl_int = -60;
+    pub const CL_INVALID_BUFFER_SIZE: cl_int = -61;
+    pub const CL_INVALID_MIP_LEVEL: cl_int = -62;
+    pub const CL_INVALID_GLOBAL_WORK_SIZE: cl_int = -63;
+    pub const CL_INVALID_PROPERTY: cl_int = -64;
+    pub const CL_INVALID_IMAGE_DESCRIPTOR: cl_int = -65;
+    pub const CL_INVALID_COMPILER_OPTIONS: cl_int = -66;
+    pub const CL_INVALID_LINKER_OPTIONS: cl_int = -67;
+    pub const CL_INVALID_DEVICE_PARTITION_COUNT: cl_int = -68;
+    pub const CL_INVALID_PIPE_SIZE: cl_int = -69;
+    pub const CL_INVALID_DEVICE_QUEUE: cl_int = -70;
+    pub const CL_INVALID_SPEC_ID: cl_int = -71;
+    pub const CL_MAX_SIZE_RESTRICTION_EXCEEDED: cl_int = -72;
+}
+

--- a/src/runtime/api/cl_error_codes.rs
+++ b/src/runtime/api/cl_error_codes.rs
@@ -1,3 +1,4 @@
+use crate::api::error_handling::cl_int;
 #[derive(Debug, Clone)]
 pub enum ClError {
     Success(ErrorDescription),
@@ -276,6 +277,7 @@ impl fmt::Display for ClError {
 }
 #[cfg(test)]
 pub mod error_codes {
+use crate::api::error_handling::cl_int;
     pub const CL_SUCCESS: cl_int = 0;
     pub const CL_DEVICE_NOT_FOUND: cl_int = -1;
     pub const CL_DEVICE_NOT_AVAILABLE: cl_int = -2;

--- a/src/runtime/api/cl_types.rs
+++ b/src/runtime/api/cl_types.rs
@@ -6,7 +6,6 @@ use crate::interface::*;
 
 use crate::sync;
 use bitflags::bitflags;
-use core::fmt;
 use ocl_type_wrapper::cl_object;
 use std::convert::TryFrom;
 
@@ -198,48 +197,9 @@ bitflags! {
     }
 }
 
-pub const CL_DEVICE_NOT_AVAILABLE: cl_int = -2;
-pub const CL_BUILD_PROGRAM_FAILURE: cl_int = -11;
-pub const CL_INVALID_PLATFORM: cl_int = -32;
-pub const CL_INVALID_DEVICE: cl_int = -33;
-pub const CL_INVALID_CONTEXT: cl_int = -34;
-pub const CL_INVALID_COMMAND_QUEUE: cl_int = -36;
-pub const CL_INVALID_MEM_OBJECT: cl_int = -38;
-pub const CL_INVALID_PROGRAM: cl_int = -44;
-pub const CL_INVALID_KERNEL: cl_int = -48;
-pub const CL_INVALID_BUFFER_SIZE: cl_int = -61;
-
-#[derive(Clone)]
-pub struct ClErrorCode<'a> {
-    pub value: cl_int,
-    pub name: &'a str,
-    pub description: &'a str,
-}
-
-impl<'a> fmt::Display for ClErrorCode<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} - {} ({})", self.value, self.name, self.description)
-    }
-}
-
-impl<'a> ClErrorCode<'a> {
-    pub(crate) const fn new(value: cl_int, name: &'a str, description: &'a str) -> Self {
-        return Self {
-            value,
-            name,
-            description,
-        };
-    }
-    pub const Success: Self = Self::new(0, "CL_SUCCESS", "Success");
-    pub const InvalidValue: Self = Self::new(
-        -30,
-        "CL_INVALID_VALUE",
-        "One of the API arguments is not valid",
-    );
-}
-
-pub const CL_SUCCESS: cl_int = ClErrorCode::Success.value;
-pub const CL_INVALID_VALUE: cl_int = ClErrorCode::InvalidValue.value;
+/// This is an exception to generic error handling mechanism, because success
+/// error code had no meaning.
+pub const CL_SUCCESS: cl_int = 0;
 
 const CL_VERSION_MAJOR_BITS: u32 = 10;
 const CL_VERSION_MINOR_BITS: u32 = 10;

--- a/src/runtime/api/device.rs
+++ b/src/runtime/api/device.rs
@@ -1,34 +1,27 @@
 use super::error_handling::ClError;
 use crate::api::cl_types::*;
 use crate::interface::{DeviceImpl, DeviceKind, PlatformImpl, PlatformKind};
-use crate::{
-    format_error, lcl_contract, return_result, set_info_array, set_info_int, set_info_str,
-};
+use crate::{lcl_contract, set_info_array, set_info_int, set_info_str, success};
+use ocl_type_wrapper::cl_api;
 use std::ops::Deref;
 
-#[no_mangle]
-pub unsafe extern "C" fn clGetDeviceIDs(
+#[cl_api]
+fn clGetDeviceIDs(
     platform: cl_platform_id,
     device_type: cl_device_type,
     num_entries: cl_uint,
     devices_raw: *mut cl_device_id,
     num_devices: *mut cl_uint,
-) -> cl_int {
-    let maybe_platform = PlatformKind::try_from_cl(platform);
-
-    lcl_contract!(
-        maybe_platform.is_ok(),
-        "platform can not be NULL",
-        CL_INVALID_PLATFORM
-    );
+) -> Result<(), ClError> {
+    let platform_safe = PlatformKind::try_from_cl(platform).map_err(|reason| {
+        ClError::InvalidPlatform(std::format!("not a valid platform: {}", reason).into())
+    })?;
 
     lcl_contract!(
         !num_devices.is_null() || !devices_raw.is_null(),
-        "ether devices or num_devices must be non-NULL",
-        CL_INVALID_VALUE
+        ClError::InvalidPlatform,
+        "ether devices or num_devices must be non-NULL"
     );
-
-    let platform_safe = maybe_platform.unwrap();
 
     // TODO figure out why mut is required here and why I can't simply borrow
     // iterators by constant reference.
@@ -41,152 +34,137 @@ pub unsafe extern "C" fn clGetDeviceIDs(
 
     if !num_devices.is_null() {
         // TODO find safe way to do this
-        *num_devices = devices.by_ref().count() as u32;
+        unsafe { *num_devices = devices.by_ref().count() as u32 };
     }
 
     if !devices_raw.is_null() {
-        let devices_array =
-            std::slice::from_raw_parts_mut(devices_raw as *mut cl_device_id, num_entries as usize);
+        let devices_array = unsafe {
+            std::slice::from_raw_parts_mut(devices_raw as *mut cl_device_id, num_entries as usize)
+        };
         for (i, d) in devices.take(num_entries as usize).enumerate() {
             let device_ptr = d.get_cl_handle();
             devices_array[i] = device_ptr;
         }
     }
 
-    return CL_SUCCESS;
+    return success!();
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn clGetDeviceInfo(
+#[cl_api]
+fn clGetDeviceInfo(
     device: cl_device_id,
     param_name_num: cl_device_info,
     _param_value_size: cl_size_t,
     param_value: *mut libc::c_void,
     param_value_size_ret: *mut cl_size_t,
-) -> cl_int {
-    let device_safe = DeviceKind::try_from_cl(device);
+) -> Result<(), ClError> {
+    let device_safe = DeviceKind::try_from_cl(device)
+        .map_err(|reason| ClError::InvalidDevice(format!("invalid device: {}", reason).into()))?;
 
-    lcl_contract!(
-        device_safe.is_ok(),
-        "device can't be NULL",
-        CL_INVALID_DEVICE
-    );
+    let param_name = DeviceInfoNames::try_from(param_name_num).map_err(|_| {
+        ClError::InvalidValue(format!("unknown param_name: {}", param_name_num).into())
+    })?;
 
-    let maybe_param_name = DeviceInfoNames::try_from(param_name_num);
-
-    let result = match maybe_param_name {
-        Ok(param_name) => {
-            match param_name {
-                DeviceInfoNames::Name => {
-                    let info = device_safe.unwrap().get_device_name();
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Vendor => {
-                    let info = device_safe.unwrap().get_vendor_name();
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::VendorId => {
-                    let info = device_safe.unwrap().get_vendor_id();
-                    set_info_int!(cl_uint, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::MaxComputeUnits => {
-                    let info = device_safe.unwrap().get_max_compute_units();
-                    set_info_int!(cl_uint, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::MaxWorkItemDimensions => {
-                    let info = device_safe.unwrap().get_max_work_item_dimensions();
-                    set_info_int!(cl_uint, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::MaxWorkItemSizes => {
-                    let info = device_safe.unwrap().get_max_work_item_sizes();
-                    set_info_array!(cl_size_t, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Available => {
-                    let info = if device_safe.unwrap().is_available() {
-                        1 as cl_bool
-                    } else {
-                        0 as cl_bool
-                    };
-                    set_info_int!(cl_bool, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::CompilerAvailable => {
-                    let info = if device_safe.unwrap().is_compiler_available() {
-                        1 as cl_bool
-                    } else {
-                        0 as cl_bool
-                    };
-                    set_info_int!(cl_bool, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::LinkerAvailable => {
-                    // With current architecture both compiler and linker are
-                    // the same component.
-                    let info = if device_safe.unwrap().is_compiler_available() {
-                        1 as cl_bool
-                    } else {
-                        0 as cl_bool
-                    };
-                    set_info_int!(cl_bool, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Platform => {
-                    let platform = device_safe.unwrap().get_platform().upgrade().unwrap();
-                    let info = platform.get_cl_handle();
-                    set_info_int!(cl_platform_id, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::ClDriverVersion => {
-                    // TODO get version dynamically
-                    let info = "LibreCL 0.1.0 over ".to_owned()
-                        + device_safe.unwrap().get_native_driver_version().as_str();
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Profile => {
-                    let info = device_safe.unwrap().get_device_profile();
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Version => {
-                    let info = String::from("OpenCL 3.0 ")
-                        + device_safe.unwrap().get_device_version_info().as_str();
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::NumericVersion => {
-                    let info = make_version(3, 0, 0);
-                    set_info_int!(cl_version, info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::OpenclCVersion => {
-                    // TODO need support for OpenCL C 2.1
-                    let info = String::from("OpenCL C 1.2");
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::Extensions => {
-                    let extensions_vec: Vec<_> =
-                        device_safe.as_ref().unwrap().get_extension_names().to_vec();
-                    let info = extensions_vec.join(" ");
-                    set_info_str!(info, param_value, param_value_size_ret)
-                }
-                DeviceInfoNames::ExtensionsWithVersion => {
-                    let names = device_safe.as_ref().unwrap().get_extension_names();
-                    let versions = device_safe.as_ref().unwrap().get_extension_versions();
-
-                    let info: Vec<_> = names
-                        .iter()
-                        .zip(versions.iter())
-                        .map(|(&n, &v)| cl_name_version {
-                            version: v,
-                            name: n.as_bytes().try_into().expect("failed to convert to array"),
-                        })
-                        .collect();
-                    set_info_array!(cl_name_version, info, param_value, param_value_size_ret)
-                }
-                _ => Err(ClError::new(
-                    ClErrorCode::InvalidValue,
-                    format!("{} is not supported yet", param_name.as_cl_str()),
-                )),
-            }
+    match param_name {
+        DeviceInfoNames::Name => {
+            let info = device_safe.get_device_name();
+            set_info_str!(info, param_value, param_value_size_ret)
         }
-        Err(_) => Err(ClError::new(
-            ClErrorCode::InvalidValue,
-            format!("unknow param_name {}", param_name_num),
-        )),
-    };
+        DeviceInfoNames::Vendor => {
+            let info = device_safe.get_vendor_name();
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::VendorId => {
+            let info = device_safe.get_vendor_id();
+            set_info_int!(cl_uint, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::MaxComputeUnits => {
+            let info = device_safe.get_max_compute_units();
+            set_info_int!(cl_uint, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::MaxWorkItemDimensions => {
+            let info = device_safe.get_max_work_item_dimensions();
+            set_info_int!(cl_uint, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::MaxWorkItemSizes => {
+            let info = device_safe.get_max_work_item_sizes();
+            set_info_array!(cl_size_t, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::Available => {
+            let info = if device_safe.is_available() {
+                1 as cl_bool
+            } else {
+                0 as cl_bool
+            };
+            set_info_int!(cl_bool, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::CompilerAvailable => {
+            let info = if device_safe.is_compiler_available() {
+                1 as cl_bool
+            } else {
+                0 as cl_bool
+            };
+            set_info_int!(cl_bool, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::LinkerAvailable => {
+            // With current architecture both compiler and linker are
+            // the same component.
+            let info = if device_safe.is_compiler_available() {
+                1 as cl_bool
+            } else {
+                0 as cl_bool
+            };
+            set_info_int!(cl_bool, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::Platform => {
+            let platform = device_safe.get_platform().upgrade().unwrap();
+            let info = platform.get_cl_handle();
+            set_info_int!(cl_platform_id, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::ClDriverVersion => {
+            // TODO get version dynamically
+            let info =
+                "LibreCL 0.1.0 over ".to_owned() + device_safe.get_native_driver_version().as_str();
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::Profile => {
+            let info = device_safe.get_device_profile();
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::Version => {
+            let info = String::from("OpenCL 3.0 ") + device_safe.get_device_version_info().as_str();
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::NumericVersion => {
+            let info = make_version(3, 0, 0);
+            set_info_int!(cl_version, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::OpenclCVersion => {
+            // TODO need support for OpenCL C 2.1
+            let info = String::from("OpenCL C 1.2");
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::Extensions => {
+            let extensions_vec: Vec<_> = device_safe.get_extension_names().to_vec();
+            let info = extensions_vec.join(" ");
+            set_info_str!(info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::ExtensionsWithVersion => {
+            let names = device_safe.get_extension_names();
+            let versions = device_safe.get_extension_versions();
 
-    return_result!(result);
+            let info: Vec<_> = names
+                .iter()
+                .zip(versions.iter())
+                .map(|(&n, &v)| cl_name_version {
+                    version: v,
+                    name: n.as_bytes().try_into().expect("failed to convert to array"),
+                })
+                .collect();
+            set_info_array!(cl_name_version, info, param_value, param_value_size_ret)
+        }
+        _ => Err(ClError::InvalidValue(
+            format!("{} is not supported yet", param_name.as_cl_str()).into(),
+        )),
+    }
 }

--- a/src/runtime/api/generate_error_codes.py
+++ b/src/runtime/api/generate_error_codes.py
@@ -64,7 +64,8 @@ errors = """#define CL_SUCCESS                                  0
 
 lines = errors.splitlines()
 
-enum = """#[derive(Debug, Clone)]
+enum = """use crate::api::error_handling::cl_int;
+#[derive(Debug, Clone)]
 pub enum ClError {
 """
 
@@ -85,6 +86,7 @@ fmt = """impl fmt::Display for ClError {
 
 test = """#[cfg(test)]
 pub mod error_codes {
+use crate::api::error_handling::cl_int;
 """
 
 for line in lines:

--- a/src/runtime/api/generate_error_codes.py
+++ b/src/runtime/api/generate_error_codes.py
@@ -1,0 +1,113 @@
+errors = """#define CL_SUCCESS                                  0
+#define CL_DEVICE_NOT_FOUND                         -1
+#define CL_DEVICE_NOT_AVAILABLE                     -2
+#define CL_COMPILER_NOT_AVAILABLE                   -3
+#define CL_MEM_OBJECT_ALLOCATION_FAILURE            -4
+#define CL_OUT_OF_RESOURCES                         -5
+#define CL_OUT_OF_HOST_MEMORY                       -6
+#define CL_PROFILING_INFO_NOT_AVAILABLE             -7
+#define CL_MEM_COPY_OVERLAP                         -8
+#define CL_IMAGE_FORMAT_MISMATCH                    -9
+#define CL_IMAGE_FORMAT_NOT_SUPPORTED               -10
+#define CL_BUILD_PROGRAM_FAILURE                    -11
+#define CL_MAP_FAILURE                              -12
+#define CL_MISALIGNED_SUB_BUFFER_OFFSET             -13
+#define CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST -14
+#define CL_COMPILE_PROGRAM_FAILURE                  -15
+#define CL_LINKER_NOT_AVAILABLE                     -16
+#define CL_LINK_PROGRAM_FAILURE                     -17
+#define CL_DEVICE_PARTITION_FAILED                  -18
+#define CL_KERNEL_ARG_INFO_NOT_AVAILABLE            -19
+#define CL_INVALID_VALUE                            -30
+#define CL_INVALID_DEVICE_TYPE                      -31
+#define CL_INVALID_PLATFORM                         -32
+#define CL_INVALID_DEVICE                           -33
+#define CL_INVALID_CONTEXT                          -34
+#define CL_INVALID_QUEUE_PROPERTIES                 -35
+#define CL_INVALID_COMMAND_QUEUE                    -36
+#define CL_INVALID_HOST_PTR                         -37
+#define CL_INVALID_MEM_OBJECT                       -38
+#define CL_INVALID_IMAGE_FORMAT_DESCRIPTOR          -39
+#define CL_INVALID_IMAGE_SIZE                       -40
+#define CL_INVALID_SAMPLER                          -41
+#define CL_INVALID_BINARY                           -42
+#define CL_INVALID_BUILD_OPTIONS                    -43
+#define CL_INVALID_PROGRAM                          -44
+#define CL_INVALID_PROGRAM_EXECUTABLE               -45
+#define CL_INVALID_KERNEL_NAME                      -46
+#define CL_INVALID_KERNEL_DEFINITION                -47
+#define CL_INVALID_KERNEL                           -48
+#define CL_INVALID_ARG_INDEX                        -49
+#define CL_INVALID_ARG_VALUE                        -50
+#define CL_INVALID_ARG_SIZE                         -51
+#define CL_INVALID_KERNEL_ARGS                      -52
+#define CL_INVALID_WORK_DIMENSION                   -53
+#define CL_INVALID_WORK_GROUP_SIZE                  -54
+#define CL_INVALID_WORK_ITEM_SIZE                   -55
+#define CL_INVALID_GLOBAL_OFFSET                    -56
+#define CL_INVALID_EVENT_WAIT_LIST                  -57
+#define CL_INVALID_EVENT                            -58
+#define CL_INVALID_OPERATION                        -59
+#define CL_INVALID_GL_OBJECT                        -60
+#define CL_INVALID_BUFFER_SIZE                      -61
+#define CL_INVALID_MIP_LEVEL                        -62
+#define CL_INVALID_GLOBAL_WORK_SIZE                 -63
+#define CL_INVALID_PROPERTY                         -64
+#define CL_INVALID_IMAGE_DESCRIPTOR                 -65
+#define CL_INVALID_COMPILER_OPTIONS                 -66
+#define CL_INVALID_LINKER_OPTIONS                   -67
+#define CL_INVALID_DEVICE_PARTITION_COUNT           -68
+#define CL_INVALID_PIPE_SIZE                        -69
+#define CL_INVALID_DEVICE_QUEUE                     -70
+#define CL_INVALID_SPEC_ID                          -71
+#define CL_MAX_SIZE_RESTRICTION_EXCEEDED            -72"""
+
+lines = errors.splitlines()
+
+enum = """#[derive(Debug, Clone)]
+pub enum ClError {
+"""
+
+impl = """impl ClError {
+    pub fn error_code(&self) -> cl_int {
+        match self {
+"""
+
+get_name = """
+    pub fn get_name(&self) -> &str {
+        match self {
+"""
+
+fmt = """impl fmt::Display for ClError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error_descr = match self {
+"""
+
+test = """#[cfg(test)]
+pub mod error_codes {
+"""
+
+for line in lines:
+    parts = line.split(" ")
+    enum_name = parts[1].replace("CL_", "")
+    enum_name = ''.join(x.title() for x in enum_name.split("_"))
+    enum = enum + "    " + enum_name + "(ErrorDescription),\n"
+    impl = impl + "            ClError::" + enum_name + "(_) => " + parts[-1] + " as cl_int,\n"
+    get_name = get_name + "            ClError::" + enum_name + "(_) => \"" + parts[1] + "\",\n"
+    fmt = fmt + "            ClError::" + enum_name + "(desc) => desc,\n"
+    test = test + "    pub const " + parts[1] + ": cl_int = " + parts[-1] + ";\n"
+
+enum = enum + "}\n"
+impl = impl + "        }\n    }\n"
+get_name = get_name + "        }\n    }\n}\n"
+fmt = fmt + """        };
+        write!(f, "{} ({}) - {} from:\\n{:?}", self.error_code(), self.get_name(), error_descr.message, error_descr.backtrace)
+    }
+}"""
+test = test + "}\n"
+
+print(enum)
+print(impl)
+print(get_name)
+print(fmt)
+print(test)

--- a/src/runtime/api/kernel.rs
+++ b/src/runtime/api/kernel.rs
@@ -1,113 +1,123 @@
-use std::ops::{Deref, DerefMut};
-
 use super::cl_types::*;
 use crate::{
-    format_error,
+    api::error_handling::{map_invalid_kernel, map_invalid_mem, map_invalid_program, ClError},
+    success,
+};
+use crate::{
     interface::{ContextImpl, KernelImpl, KernelKind, MemKind, ProgramImpl, ProgramKind},
     lcl_contract,
     sync::SharedPtr,
 };
 use librecl_compiler::KernelArgType;
+use ocl_type_wrapper::cl_api;
+use std::ops::{Deref, DerefMut};
 
-#[no_mangle]
-pub unsafe extern "C" fn clCreateKernel(
+#[cl_api]
+fn clCreateKernel(
     program: cl_program,
     kernel_name: *const libc::c_char,
-    errcode_ret: *mut cl_int,
-) -> cl_kernel {
-    lcl_contract!(
-        !program.is_null(),
-        "program can't be NULL",
-        CL_INVALID_PROGRAM,
-        errcode_ret
-    );
+) -> Result<cl_kernel, ClError> {
+    let program_safe = ProgramKind::try_from_cl(program).map_err(map_invalid_program)?;
 
-    let program_safe = ProgramKind::try_from_cl(program).unwrap();
-
-    let context = program_safe.get_context().upgrade().unwrap();
+    let context = program_safe
+        .get_context()
+        .upgrade()
+        .ok_or(())
+        .map_err(|_| {
+            ClError::InvalidContext(
+                "failed to acquire owning reference to queue. Was it released before?".into(),
+            )
+        })?;
 
     lcl_contract!(
         context,
         !kernel_name.is_null(),
-        "kernel_name can't be NULL",
-        CL_INVALID_VALUE,
-        errcode_ret
+        ClError::InvalidValue,
+        "kernel_name can't be NULL"
     );
 
-    let kernel_name_safe = std::ffi::CStr::from_ptr(kernel_name)
+    let kernel_name_safe = unsafe { std::ffi::CStr::from_ptr(kernel_name) }
         .to_str()
         .unwrap_or_default();
     lcl_contract!(
         context,
         !kernel_name_safe.is_empty(),
-        "kernel_name can't be empty",
-        CL_INVALID_VALUE,
-        errcode_ret
+        ClError::InvalidValue,
+        "kernel_name can't be empty"
     );
 
+    // TODO return Result<KernelKind, ClError>
     let kernel = program_safe.create_kernel(kernel_name_safe);
-    *errcode_ret = CL_SUCCESS;
 
-    return _cl_kernel::wrap(kernel);
+    return Ok(_cl_kernel::wrap(kernel));
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn clSetKernelArg(
+#[cl_api]
+fn clSetKernelArg(
     kernel: cl_kernel,
     arg_index: cl_uint,
     arg_size: cl_size_t,
     arg_value: *const libc::c_void,
-) -> cl_int {
+) -> Result<(), ClError> {
     // TODO proper error handling
-    lcl_contract!(!kernel.is_null(), "kernel can't be NULL", CL_INVALID_VALUE);
     lcl_contract!(
         !arg_value.is_null(),
-        "arg_value can't be NULL",
-        CL_INVALID_VALUE
+        ClError::InvalidValue,
+        "arg_value can't be NULL"
     );
 
-    let mut kernel_safe = KernelKind::try_from_cl(kernel).unwrap();
+    let mut kernel_safe = KernelKind::try_from_cl(kernel).map_err(map_invalid_kernel)?;
 
     let arg_info = kernel_safe.deref().get_arg_info()[arg_index as usize].clone();
 
     match arg_info.arg_type {
         KernelArgType::GlobalBuffer => {
-            let mem = MemKind::try_from_cl(*(arg_value as *const cl_mem)).unwrap();
+            let mem = MemKind::try_from_cl(unsafe { *(arg_value as *const cl_mem) })
+                .map_err(map_invalid_mem)?;
             kernel_safe
                 .deref_mut()
                 .set_buffer_arg(arg_index as usize, SharedPtr::downgrade(&mem));
         }
-        KernelArgType::POD => kernel_safe.deref_mut().set_data_arg(
-            arg_index as usize,
-            std::slice::from_raw_parts(arg_value as *const u8, arg_size as usize),
-        ),
+        KernelArgType::POD => kernel_safe
+            .deref_mut()
+            .set_data_arg(arg_index as usize, unsafe {
+                std::slice::from_raw_parts(arg_value as *const u8, arg_size as usize)
+            }),
         _ => panic!("Unsupported!"),
     }
 
-    return CL_SUCCESS;
+    return success!();
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn clRetainKernel(kernel: cl_kernel) -> cl_int {
-    lcl_contract!(!kernel.is_null(), "kernel can't be NULL", CL_INVALID_KERNEL);
+#[cl_api]
+fn clRetainKernel(kernel: cl_kernel) -> Result<(), ClError> {
+    lcl_contract!(
+        !kernel.is_null(),
+        ClError::InvalidKernel,
+        "kernel can't be NULL"
+    );
 
-    let kernel_ref = &mut *kernel;
+    let kernel_ref = unsafe { &mut *kernel };
 
     kernel_ref.retain();
 
-    return CL_SUCCESS;
+    return success!();
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn clReleaseKernel(kernel: cl_kernel) -> cl_int {
-    lcl_contract!(!kernel.is_null(), "kernel can't be NULL", CL_INVALID_KERNEL);
+#[cl_api]
+fn clReleaseKernel(kernel: cl_kernel) -> Result<(), ClError> {
+    lcl_contract!(
+        !kernel.is_null(),
+        ClError::InvalidKernel,
+        "kernel can't be NULL"
+    );
 
-    let kernel_ref = &mut *kernel;
+    let kernel_ref = unsafe { &mut *kernel };
 
     if kernel_ref.release() == 1 {
         // Intentionally ignore value to destroy pointer and its content
-        Box::from_raw(kernel);
+        unsafe { Box::from_raw(kernel) };
     }
 
-    return CL_SUCCESS;
+    return success!();
 }

--- a/src/runtime/vulkan/device.rs
+++ b/src/runtime/vulkan/device.rs
@@ -195,4 +195,3 @@ impl DeviceImpl for Device {
         &self.extension_versions
     }
 }
-

--- a/utils/ocl_type_wrapper/Cargo.toml
+++ b/utils/ocl_type_wrapper/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 syn = "1.0.98"
 quote = "1.0.20"
 darling = "0.14.1"
+convert_case = "0.5.0"
 
 [build-dependencies]
 

--- a/utils/ocl_type_wrapper/src/lib.rs
+++ b/utils/ocl_type_wrapper/src/lib.rs
@@ -1,6 +1,10 @@
 extern crate proc_macro;
+use std::ops::Deref;
+
+use convert_case::{Case, Casing};
 use darling::{FromDeriveInput, FromField};
 use proc_macro::TokenStream;
+use quote::format_ident;
 use quote::quote;
 use syn::{self, parse_macro_input, DeriveInput};
 
@@ -46,12 +50,12 @@ pub fn cl_object(args: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         impl FromCl<*mut #name> for #dependent {
-            type Error = ();
+            type Error = String;
 
             fn try_from_cl(value: *mut #name) -> Result<sync::SharedPtr<#dependent>, Self::Error> {
                 match unsafe { value.as_ref() } {
                     Some(obj) => Ok(obj.handle.clone()),
-                    None => Err(()),
+                    None => Err("value is NULL".to_owned()),
                 }
             }
         }
@@ -116,7 +120,102 @@ pub fn derive(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-mod test {
-    #[test]
-    fn derive_macro_parsing() {}
+#[proc_macro_attribute]
+pub fn cl_api(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as syn::ItemFn);
+
+    let body = input.block.clone();
+
+    let func_name = input.sig.ident.clone();
+    // TODO correctly handle IDs, KHR and LCL patterns.
+    let func_name_str = func_name.clone().to_string();
+    let func_name_processed = func_name_str
+        .clone()
+        .replace("IDs", "_ids")
+        .replace("KHR", "_khr")
+        .replace("LCL", "_lcl");
+    let impl_name = format_ident!(
+        "{}_impl",
+        func_name_processed
+            .from_case(Case::Camel)
+            .to_case(Case::Snake)
+    );
+
+    let args = input.sig.inputs.clone();
+    let arg_names = args.clone().into_iter().map(|arg| match arg {
+        syn::FnArg::Typed(pat) => pat.pat,
+        _ => panic!(),
+    });
+
+    let return_type = match input.sig.output {
+        syn::ReturnType::Type(_, ret_type) => ret_type,
+        _ => panic!(),
+    };
+
+    let cl_object_type = match return_type.deref() {
+        syn::Type::Path(path) => {
+            let first = path.path.segments.first();
+            let result = first.unwrap();
+            match result.arguments.clone() {
+                syn::PathArguments::AngleBracketed(b) => {
+                    let first = b.args.first().unwrap().clone();
+                    match first {
+                        syn::GenericArgument::Type(ty) => ty,
+                        _ => panic!(),
+                    }
+                }
+                _ => panic!(),
+            }
+        }
+        _ => panic!(),
+    };
+
+    let api = match cl_object_type {
+        syn::Type::Tuple(_) => {
+            quote! {
+                #[no_mangle]
+                pub(crate) unsafe extern "C" fn #func_name(#args) -> cl_int {
+                    let result = #impl_name(#(#arg_names),*);
+                    match result {
+                        Ok(_) => 0,
+                        Err(err) => {
+                            tracing::error!("{}", err);
+                            err.error_code()
+                        }
+                    }
+                }
+            }
+        }
+        _ => {
+            quote! {
+                #[no_mangle]
+                pub(crate) unsafe extern "C" fn #func_name(#args errorcode_ret: *mut cl_int) -> #cl_object_type {
+                    let result = #impl_name(#(#arg_names),*);
+                    match result {
+                        Ok(ret) => {
+                            if !errorcode_ret.is_null() {
+                                *errorcode_ret = 0;
+                            }
+                            ret
+                        },
+                        Err(err) => {
+                            tracing::error!("{}", err);
+                            if !errorcode_ret.is_null() {
+                                *errorcode_ret = err.error_code();
+                            }
+                            std::ptr::null_mut()
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    let gen = quote! {
+        fn #impl_name(#args) -> #return_type #body
+
+        #api
+    };
+
+    gen.into()
 }

--- a/utils/ocl_type_wrapper/src/lib.rs
+++ b/utils/ocl_type_wrapper/src/lib.rs
@@ -175,6 +175,7 @@ pub fn cl_api(_args: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #[no_mangle]
                 pub(crate) unsafe extern "C" fn #func_name(#args) -> cl_int {
+                    let _span_ = tracing::span!(tracing::Level::TRACE, #func_name_str).entered();
                     let result = #impl_name(#(#arg_names),*);
                     match result {
                         Ok(_) => 0,
@@ -190,6 +191,7 @@ pub fn cl_api(_args: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #[no_mangle]
                 pub(crate) unsafe extern "C" fn #func_name(#args errorcode_ret: *mut cl_int) -> #cl_object_type {
+                    let _span_ = tracing::span!(tracing::Level::TRACE, #func_name_str).entered();
                     let result = #impl_name(#(#arg_names),*);
                     match result {
                         Ok(ret) => {


### PR DESCRIPTION
New error handling mechanism works through Rust macros system to
override functions' signatures. With these changes, APIs now always
return `Result<_, ClError>` type, which allows for easier error
propagation from backends to user. All errors come with attached error
message and backtrace, which should improve debuggability. Additionally,
errors are now reported via `tracing` crate with the intention to expose
these diagnostics to env variable-guarded console printing, open
telemetry and XPTI.