### PR TITLE
feat(rt): improve support for device info queries

### DIFF
--- a/src/runtime/api/cl_types.rs
+++ b/src/runtime/api/cl_types.rs
@@ -90,11 +90,11 @@ pub const CL_DEVICE_TYPE_ALL: libc::c_ulong = 0xFFFFFFFF;
 bitflags! {
     #[repr(C)]
     pub struct cl_device_type: libc::c_ulong {
-        const DefaultDevice = 0;
-        const CPU = 1;
-        const GPU = 2;
-        const ACC = 3;
-        const CustomDevice = 4;
+        const DefaultDevice = 0b00000001;
+        const CPU = 0b00000010;
+        const GPU = 0b00000100;
+        const ACC = 0b00001000;
+        const CustomDevice = 0b00010000;
     }
 }
 

--- a/src/runtime/api/device.rs
+++ b/src/runtime/api/device.rs
@@ -1,6 +1,6 @@
 use super::error_handling::ClError;
 use crate::api::cl_types::*;
-use crate::interface::{DeviceImpl, DeviceKind, PlatformImpl, PlatformKind, DeviceLimitsInterface};
+use crate::interface::{DeviceImpl, DeviceKind, DeviceLimitsInterface, PlatformImpl, PlatformKind};
 use crate::{lcl_contract, set_info_array, set_info_int, set_info_str, success};
 use ocl_type_wrapper::cl_api;
 use std::ops::Deref;
@@ -66,6 +66,10 @@ fn clGetDeviceInfo(
     })?;
 
     match param_name {
+        DeviceInfoNames::Type => {
+            let info: cl_ulong = device_safe.get_device_type().bits();
+            set_info_int!(cl_ulong, info, param_value, param_value_size_ret)
+        }
         DeviceInfoNames::Name => {
             let info = device_safe.get_device_name();
             set_info_str!(info, param_value, param_value_size_ret)
@@ -230,6 +234,14 @@ fn clGetDeviceInfo(
         DeviceInfoNames::PreferredWorkGroupSizeMultiple => {
             let info = device_safe.preferred_work_group_size_multiple();
             set_info_int!(cl_size_t, info, param_value, param_value_size_ret)
+        }
+        DeviceInfoNames::ParentDevice => {
+            set_info_int!(
+                cl_device_id,
+                (std::ptr::null_mut()),
+                param_value,
+                param_value_size_ret
+            )
         }
         _ => Err(ClError::InvalidValue(
             format!("{} is not supported yet", param_name.as_cl_str()).into(),

--- a/src/runtime/vulkan/device.rs
+++ b/src/runtime/vulkan/device.rs
@@ -53,7 +53,7 @@ impl Device {
             },
         )
         .expect("could not create a device");
-        // TODO correct device type
+
         let device_type = match physical_device.properties().device_type {
             PhysicalDeviceType::Cpu => cl_device_type::CPU,
             PhysicalDeviceType::IntegratedGpu => cl_device_type::GPU,


### PR DESCRIPTION
Just enough to run `sycl-ls --verbose` on Vulkan backend.